### PR TITLE
Simplify usage calculations and add tests

### DIFF
--- a/psfdx.Tests.ps1
+++ b/psfdx.Tests.ps1
@@ -98,5 +98,22 @@ Describe 'psfdx module' {
                 $out.ok | Should -BeTrue
             }
         }
+
+        Context 'Get-SalesforceDataStorage' {
+            It 'calculates in-use and usage from limits' {
+                Mock Get-SalesforceLimits { @{ max = 100; remaining = 40 } } -ModuleName $module.Name
+                $res = Get-SalesforceDataStorage -Username me
+                $res.InUse | Should -Be 60
+                $res.Usage | Should -Be ((60/100).ToString('P'))
+            }
+        }
+
+        Context 'Get-SalesforceApiUsage' {
+            It 'calculates usage from limits' {
+                Mock Get-SalesforceLimits { @{ max = 1000; remaining = 250 } } -ModuleName $module.Name
+                $res = Get-SalesforceApiUsage -Username me
+                $res.Usage | Should -Be ((750/1000).ToString('P'))
+            }
+        }
     }
 }

--- a/psfdx.psm1
+++ b/psfdx.psm1
@@ -171,8 +171,9 @@ function Get-SalesforceDataStorage {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Username)
     $values = Get-SalesforceLimits -Username $Username | Where-Object Name -eq "DataStorageMB"
-    $values | Add-Member -NotePropertyName InUse -NotePropertyValue ($values.max + ($values.remaining * -1))
-    $values | Add-Member -NotePropertyName Usage -NotePropertyValue (($values.max + ($values.remaining * -1)) / $values.max).ToString('P')
+    $inUse = $values.max - $values.remaining
+    $values | Add-Member -NotePropertyName InUse -NotePropertyValue $inUse
+    $values | Add-Member -NotePropertyName Usage -NotePropertyValue ($inUse / $values.max).ToString('P')
     return $values
 }
 
@@ -180,7 +181,8 @@ function Get-SalesforceApiUsage {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Username)
     $values = Get-SalesforceLimits -Username $Username | Where-Object Name -eq "DailyApiRequests"
-    $values | Add-Member -NotePropertyName Usage -NotePropertyValue (($values.max + ($values.remaining * -1)) / $values.max).ToString('P')
+    $inUse = $values.max - $values.remaining
+    $values | Add-Member -NotePropertyName Usage -NotePropertyValue ($inUse / $values.max).ToString('P')
     return $values
 }
 


### PR DESCRIPTION
## Summary
- compute Salesforce limit usage with `max - remaining`
- add Pester tests covering data storage and API usage helpers

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path . -CI"` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden from repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68bd520f83a48324876d9e5d87cb433f