### PR TITLE
Rename Clean-SalesforceConnections to Repair-SalesforceConnections

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Get-Command -Module psfdx
 * `Disconnect-Salesforce` - Logout from orgs
 * `Connect-SalesforceJwt` - JWT-based authentication
 * `Get-SalesforceConnections` - List connected orgs
-* `Clean-SalesforceConnections` - Clean up stale connections
+* `Repair-SalesforceConnections` - Clean up stale connections
 ### Record Operations
 * `Select-SalesforceObjects` - SOQL queries with flexible output formats
 * `New-SalesforceObject` - Create records

--- a/psfdx.psm1
+++ b/psfdx.psm1
@@ -131,7 +131,7 @@ function Get-SalesforceConnections {
     return $result
 }
 
-function Clean-SalesforceConnections {
+function Repair-SalesforceConnections {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $false)][switch] $NoPrompt)
     $arguments = "org list --clean"
@@ -370,7 +370,7 @@ Export-ModuleMember Disconnect-Salesforce
 Export-ModuleMember Connect-SalesforceJwt
 Export-ModuleMember Open-Salesforce
 Export-ModuleMember Get-SalesforceConnections
-Export-ModuleMember Clean-SalesforceConnections
+Export-ModuleMember Repair-SalesforceConnections
 
 Export-ModuleMember Get-SalesforceAlias
 Export-ModuleMember Add-SalesforceAlias


### PR DESCRIPTION
## Summary
- rename Clean-SalesforceConnections command to Repair-SalesforceConnections
- update module exports and documentation references

## Testing
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path . -CI"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd76f1446483249c3d23aa86a1ede6