### PR TITLE
Fix Pester module manifest path

### DIFF
--- a/psfdx/tests/psfdx.Tests.ps1
+++ b/psfdx/tests/psfdx.Tests.ps1
@@ -6,8 +6,8 @@ Run with:
 pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path . -CI"
 #>
 
-$here = Split-Path -Parent $PSCommandPath
-$moduleManifest = Join-Path $here '..' 'psfdx' 'psfdx.psd1'
+$here = $PSScriptRoot
+$moduleManifest = Join-Path $here '..' 'psfdx.psd1'
 $module = Import-Module $moduleManifest -Force -PassThru
 
 Describe 'psfdx module' {


### PR DESCRIPTION
- Use  for robust relative resolution
- Correct manifest path to 

This fixes Pester failing to import the module:
> The specified module '.../psfdx/tests/../psfdx/psfdx.psd1' was not loaded because no valid module file was found in any module directory.

CI should now load the module and run tests across OSes.