### PR TITLE
tests(psfdx): fix manifest path for tests in module dir

### DIFF
--- a/psfdx/psfdx.Tests.ps1
+++ b/psfdx/psfdx.Tests.ps1
@@ -7,7 +7,7 @@ pwsh -NoLogo -NoProfile -Command "Invoke-Pester -Path . -CI"
 #>
 
 $here = $PSScriptRoot
-$moduleManifest = Join-Path $here '..' 'psfdx.psd1'
+$moduleManifest = Join-Path $here 'psfdx.psd1'
 $module = Import-Module $moduleManifest -Force -PassThru
 
 Describe 'psfdx module' {


### PR DESCRIPTION
Pester on Windows failed to import the module due to an incorrect manifest path when tests reside directly in the  directory.

- Use  and load  from the same directory as the test file.
- This avoids  which pointed to repo root on Windows runners ().

CI should now correctly import the module across OSes.