### PR TITLE
chore(install): modernize Linux installer

### DIFF
--- a/install-linux.ps1
+++ b/install-linux.ps1
@@ -1,8 +1,30 @@
-sudo rm -rf /opt/microsoft/powershell/7/Modules/psfdx
-sudo cp -rf psfdx /opt/microsoft/powershell/7/Modules/
+$ErrorActionPreference = 'Stop'
 
-sudo rm -rf /opt/microsoft/powershell/7/Modules/psfdx-logs
-sudo cp -rf psfdx-logs /opt/microsoft/powershell/7/Modules/
+# Modules to install
+$modules = @(
+    'psfdx',
+    'psfdx-logs',
+    'psfdx-development',
+    'psfdx-metadata',
+    'psfdx-packages'
+)
 
-sudo rm -rf /opt/microsoft/powershell/7/Modules/psfdx-development
-sudo cp -rf psfdx-development /opt/microsoft/powershell/7/Modules/
+$dest = Join-Path $PSHOME 'Modules'
+if (-not (Test-Path -Path $dest)) {
+    New-Item -Path $dest -ItemType Directory -Force | Out-Null
+}
+
+foreach ($m in $modules) {
+    $src = Join-Path (Get-Location) $m
+    if (-not (Test-Path -Path $src)) {
+        Write-Verbose "Skipping missing module source: $src"
+        continue
+    }
+    $target = Join-Path $dest $m
+    if (Test-Path -Path $target) {
+        Remove-Item -Path $target -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Copy-Item -Path $src -Destination $dest -Recurse -Force
+}
+
+Write-Host "Installed modules to: $dest" -ForegroundColor Green


### PR DESCRIPTION
Modernizes the Linux install script:\n\n- Switch to PowerShell-native Remove-Item/Copy-Item\n- Install to `/Modules` (supports PS 7.x paths)\n- Include all modules: psfdx, psfdx-logs, psfdx-development, psfdx-metadata, psfdx-packages\n- Add error stopping and a simple completion message\n\nNote: Installing to `/Modules` still requires elevation; run via `sudo pwsh -File install-linux.ps1` or equivalent.