### PR TITLE
chore(install): explicit named parameters in installers

### DIFF
--- a/install-linux.ps1
+++ b/install-linux.ps1
@@ -16,10 +16,10 @@ $modules = @(
 )
 
 if ($Scope -eq 'AllUsers') {
-    $dest = Join-Path $PSHOME 'Modules'
+    $dest = Join-Path -Path $PSHOME -ChildPath 'Modules'
 } else {
-    $xdg = if ($env:XDG_DATA_HOME) { $env:XDG_DATA_HOME } else { Join-Path $HOME '.local/share' }
-    $dest = Join-Path $xdg 'powershell/Modules'
+    $xdg = if ($env:XDG_DATA_HOME) { $env:XDG_DATA_HOME } else { Join-Path -Path $HOME -ChildPath '.local/share' }
+    $dest = Join-Path -Path $xdg -ChildPath 'powershell/Modules'
 }
 
 if (-not (Test-Path -Path $dest)) {
@@ -27,12 +27,12 @@ if (-not (Test-Path -Path $dest)) {
 }
 
 foreach ($m in $modules) {
-    $src = Join-Path (Get-Location) $m
+    $src = Join-Path -Path (Get-Location).Path -ChildPath $m
     if (-not (Test-Path -Path $src)) {
         Write-Verbose "Skipping missing module source: $src"
         continue
     }
-    $target = Join-Path $dest $m
+    $target = Join-Path -Path $dest -ChildPath $m
     if (Test-Path -Path $target) {
         Remove-Item -Path $target -Recurse -Force -ErrorAction SilentlyContinue
     }

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -16,9 +16,9 @@ $modules = @(
 )
 
 if ($Scope -eq 'AllUsers') {
-    $dest = Join-Path $PSHOME 'Modules'
+    $dest = Join-Path -Path $PSHOME -ChildPath 'Modules'
 } else {
-    $dest = Join-Path $HOME 'Documents/PowerShell/Modules'
+    $dest = Join-Path -Path $HOME -ChildPath 'Documents/PowerShell/Modules'
 }
 
 if (-not (Test-Path -Path $dest)) {
@@ -26,12 +26,12 @@ if (-not (Test-Path -Path $dest)) {
 }
 
 foreach ($m in $modules) {
-    $src = Join-Path (Get-Location) $m
+    $src = Join-Path -Path (Get-Location).Path -ChildPath $m
     if (-not (Test-Path -Path $src)) {
         Write-Verbose "Skipping missing module source: $src"
         continue
     }
-    $target = Join-Path $dest $m
+    $target = Join-Path -Path $dest -ChildPath $m
     if (Test-Path -Path $target) {
         Remove-Item -Path $target -Recurse -Force -ErrorAction SilentlyContinue
     }


### PR DESCRIPTION
Make installers explicit and consistent:\n\n- Use  everywhere\n- Use  with Join-Path\n- Keeps Linux and Windows scripts in parity\n\nNo behavior change; improves readability and avoids ambiguity.