### PR TITLE
feat: add missing module manifests (psd1)

### DIFF
--- a/psfdx-metadata/psfdx-metadata.psd1
+++ b/psfdx-metadata/psfdx-metadata.psd1
@@ -1,0 +1,40 @@
+@{
+    RootModule            = 'psfdx-metadata.psm1'
+    ModuleVersion         = '0.1.0'
+    CompatiblePSEditions  = @('Desktop','Core')
+    GUID                  = 'e0c7c8c3-0f5f-4662-a9e1-2c3c5a1c7f20'
+    Author                = 'Tony Ward'
+    CompanyName           = 'psfdx'
+    Copyright            = 'Copyright (c) psfdx contributors.'
+    Description           = 'PowerShell helpers for retrieving, deploying, and describing Salesforce metadata.'
+    PowerShellVersion     = '5.1'
+    RequiredModules       = @()
+    RequiredAssemblies    = @()
+    ScriptsToProcess      = @()
+    TypesToProcess        = @()
+    FormatsToProcess      = @()
+    FunctionsToExport     = @(
+        'Retrieve-SalesforceOrg',
+        'Retrieve-SalesforceComponent',
+        'Retrieve-SalesforceField',
+        'Retrieve-SalesforceValidationRule',
+        'Deploy-SalesforceComponent',
+        'Describe-SalesforceObjects',
+        'Describe-SalesforceObject',
+        'Describe-SalesforceFields',
+        'Get-SalesforceMetaTypes',
+        'Get-SalesforceApexClass',
+        'Build-SalesforceQuery'
+    )
+    CmdletsToExport       = @()
+    VariablesToExport     = @()
+    AliasesToExport       = @()
+    PrivateData           = @{
+        PSData = @{
+            Tags        = @('Salesforce','SFDX','Metadata')
+            ProjectUri  = 'https://github.com/tonygward/psfdx'
+            ReleaseNotes = 'Initial manifest for psfdx-metadata.'
+        }
+    }
+}
+

--- a/psfdx-packages/psfdx-packages.psd1
+++ b/psfdx-packages/psfdx-packages.psd1
@@ -1,0 +1,38 @@
+@{
+    RootModule            = 'psfdx-packages.psm1'
+    ModuleVersion         = '0.1.0'
+    CompatiblePSEditions  = @('Desktop','Core')
+    GUID                  = '0d7f0c6c-8f1b-4eb6-9f6a-55f7a7c3f2b1'
+    Author                = 'Tony Ward'
+    CompanyName           = 'psfdx'
+    Copyright            = 'Copyright (c) psfdx contributors.'
+    Description           = 'PowerShell helpers for Salesforce packages: list, create, version, promote, install.'
+    PowerShellVersion     = '5.1'
+    RequiredModules       = @()
+    RequiredAssemblies    = @()
+    ScriptsToProcess      = @()
+    TypesToProcess        = @()
+    FormatsToProcess      = @()
+    FunctionsToExport     = @(
+        'Get-SalesforcePackages',
+        'Get-SalesforcePackage',
+        'New-SalesforcePackage',
+        'Remove-SalesforcePackage',
+        'Get-SalesforcePackageVersions',
+        'New-SalesforcePackageVersion',
+        'Promote-SalesforcePackageVersion',
+        'Remove-SalesforcePackageVersion',
+        'Install-SalesforcePackageVersion'
+    )
+    CmdletsToExport       = @()
+    VariablesToExport     = @()
+    AliasesToExport       = @()
+    PrivateData           = @{
+        PSData = @{
+            Tags        = @('Salesforce','SFDX','Packages')
+            ProjectUri  = 'https://github.com/tonygward/psfdx'
+            ReleaseNotes = 'Initial manifest for psfdx-packages.'
+        }
+    }
+}
+


### PR DESCRIPTION
Adds manifests for modules missing .psd1 files.\n\n- psfdx-metadata/psfdx-metadata.psd1 with explicit FunctionsToExport matching Export-ModuleMember\n- psfdx-packages/psfdx-packages.psd1 with explicit FunctionsToExport\n\nBoth include CompatiblePSEditions, metadata, and tags — consistent with existing modules.