### PR TITLE
chore(manifests): disable CmdletNameChecking in all modules

### DIFF
--- a/psfdx-development/psfdx-development.psd1
+++ b/psfdx-development/psfdx-development.psd1
@@ -22,6 +22,7 @@
 
     # Description of the functionality provided by this module
     Description       = 'PowerShell helpers for Salesforce DX development workflows (projects, scratch orgs, tests, deploy).'
+    CmdletNameChecking = $false
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'

--- a/psfdx-logs/psfdx-logs.psd1
+++ b/psfdx-logs/psfdx-logs.psd1
@@ -22,6 +22,7 @@
 
     # Description of the functionality provided by this module
     Description       = 'PowerShell helpers for working with Salesforce DX (sf) Apex logs.'
+    CmdletNameChecking = $false
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'
@@ -71,4 +72,3 @@
         }
     }
 }
-

--- a/psfdx-metadata/psfdx-metadata.psd1
+++ b/psfdx-metadata/psfdx-metadata.psd1
@@ -7,6 +7,7 @@
     CompanyName           = 'psfdx'
     Copyright            = 'Copyright (c) psfdx contributors.'
     Description           = 'PowerShell helpers for retrieving, deploying, and describing Salesforce metadata.'
+    CmdletNameChecking    = $false
     PowerShellVersion     = '5.1'
     RequiredModules       = @()
     RequiredAssemblies    = @()
@@ -37,4 +38,3 @@
         }
     }
 }
-

--- a/psfdx-packages/psfdx-packages.psd1
+++ b/psfdx-packages/psfdx-packages.psd1
@@ -7,6 +7,7 @@
     CompanyName           = 'psfdx'
     Copyright            = 'Copyright (c) psfdx contributors.'
     Description           = 'PowerShell helpers for Salesforce packages: list, create, version, promote, install.'
+    CmdletNameChecking    = $false
     PowerShellVersion     = '5.1'
     RequiredModules       = @()
     RequiredAssemblies    = @()
@@ -35,4 +36,3 @@
         }
     }
 }
-

--- a/psfdx/psfdx.psd1
+++ b/psfdx/psfdx.psd1
@@ -4,6 +4,7 @@
     GUID = '2785d2bf-775f-4f2b-9d00-ee98f0163cf0'
     Author = 'Tony Ward'
     Description = 'PowerShell module that wraps Salesforce SFDX command line interface'
+    CmdletNameChecking = $false
     FunctionsToExport = '*'
     CmdletsToExport = @()
     AliasesToExport = @()


### PR DESCRIPTION
Disable cmdlet-name checking in all module manifests to suppress ApprovedVerbs/NameChecking lint warnings at import time.\n\nUpdated:\n- psfdx/psfdx.psd1\n- psfdx-logs/psfdx-logs.psd1\n- psfdx-development/psfdx-development.psd1\n- psfdx-metadata/psfdx-metadata.psd1\n- psfdx-packages/psfdx-packages.psd1