### PR TITLE
test(pester): import modules at discovery, use InModuleScope across suites

### DIFF
--- a/psfdx-development/psfdx-development.psd1
+++ b/psfdx-development/psfdx-development.psd1
@@ -22,7 +22,6 @@
 
     # Description of the functionality provided by this module
     Description       = 'PowerShell helpers for Salesforce DX development workflows (projects, scratch orgs, tests, deploy).'
-    CmdletNameChecking = $false
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'

--- a/psfdx-logs/psfdx-logs.Tests.ps1
+++ b/psfdx-logs/psfdx-logs.Tests.ps1
@@ -1,86 +1,76 @@
-BeforeAll {
-    $moduleManifest = Join-Path $PSScriptRoot 'psfdx-logs.psd1'
-    Import-Module $moduleManifest -Force
-}
+# Import module at discovery time so InModuleScope can find it
+$moduleManifest = Join-Path -Path $PSScriptRoot -ChildPath 'psfdx-logs.psd1'
+Import-Module $moduleManifest -Force | Out-Null
 
 Describe 'Watch-SalesforceLogs' {
-    BeforeEach {
-        # Default mock to capture commands
-        Mock -ModuleName 'psfdx-logs' Invoke-Sf {}
-    }
-
-    It 'builds base command with color' {
-        Watch-SalesforceLogs | Out-Null
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --color' }
-    }
-
-    It 'adds username when provided' {
-        Watch-SalesforceLogs -TargetOrg 'user@example' | Out-Null
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --target-org user@example --color' }
-    }
-
-    It 'adds skip trace flag' {
-        Watch-SalesforceLogs -SkipTraceFlag | Out-Null
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --skip-trace-flag --color' }
-    }
-
-    It 'adds debug level when provided' {
-        Watch-SalesforceLogs -DebugLevel 'SFDC_DevConsole' | Out-Null
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --debug-level SFDC_DevConsole --color' }
+    InModuleScope 'psfdx-logs' {
+        BeforeEach { Mock Invoke-Sf {} }
+        It 'builds base command with color' {
+            Watch-SalesforceLogs | Out-Null
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --color' }
+        }
+        It 'adds username when provided' {
+            Watch-SalesforceLogs -TargetOrg 'user@example' | Out-Null
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --target-org user@example --color' }
+        }
+        It 'adds skip trace flag' {
+            Watch-SalesforceLogs -SkipTraceFlag | Out-Null
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --skip-trace-flag --color' }
+        }
+        It 'adds debug level when provided' {
+            Watch-SalesforceLogs -DebugLevel 'SFDC_DevConsole' | Out-Null
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --debug-level SFDC_DevConsole --color' }
+        }
     }
 }
 
 Describe 'Get-SalesforceLogs' {
-    BeforeEach {
-        Mock -ModuleName 'psfdx-logs' Invoke-Sf { '{"status":0,"result":[{"Id":"1"}]}' }
-        Mock -ModuleName 'psfdx-logs' Show-SfResult { return @(@{ Id = '1' }) }
-    }
-
-    It 'lists logs with json' {
-        $out = Get-SalesforceLogs
-        $out | Should -Not -BeNullOrEmpty
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --json' }
-        Assert-MockCalled -ModuleName 'psfdx-logs' Show-SfResult -Times 1
-    }
-
-    It 'adds username when provided' {
-        Get-SalesforceLogs -TargetOrg 'user@example' | Out-Null
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --target-org user@example --json' }
+    InModuleScope 'psfdx-logs' {
+        BeforeEach {
+            Mock Invoke-Sf { '{"status":0,"result":[{"Id":"1"}]}' }
+            Mock Show-SfResult { return @(@{ Id = '1' }) }
+        }
+        It 'lists logs with json' {
+            $out = Get-SalesforceLogs
+            $out | Should -Not -BeNullOrEmpty
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --json' }
+            Assert-MockCalled Show-SfResult -Times 1
+        }
+        It 'adds username when provided' {
+            Get-SalesforceLogs -TargetOrg 'user@example' | Out-Null
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --target-org user@example --json' }
+        }
     }
 }
 
 Describe 'Get-SalesforceLog' {
-    BeforeEach {
-        # Default successful response from sf
-        $jsonOk = '{"status":0,"result":{"log":"LOGDATA"}}'
-        Mock -ModuleName 'psfdx-logs' Invoke-Sf { $jsonOk }
-    }
-
-    It 'requires either LogId or Last' {
-        { Get-SalesforceLog -TargetOrg 'user' } | Should -Throw
-    }
-
-    It 'fetches by LogId and returns log text' {
-        $log = Get-SalesforceLog -LogId '07Lxx0000000001' -TargetOrg 'user'
-        $log | Should -Be 'LOGDATA'
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log get --log-id 07Lxx0000000001 --target-org user --json' }
-    }
-
-    It 'uses -Last to get latest log id' {
-        $logs = @(
-            [pscustomobject]@{ Id = '2'; StartTime = [datetime]'2020-01-02' },
-            [pscustomobject]@{ Id = '1'; StartTime = [datetime]'2020-01-01' }
-        )
-        Mock -ModuleName 'psfdx-logs' Get-SalesforceLogs { $logs }
-
-        $null = Get-SalesforceLog -Last -TargetOrg 'user'
-        # Should pick Id '2' (latest)
-        Assert-MockCalled -ModuleName 'psfdx-logs' Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -match '--log-id 2 ' }
-    }
-
-    It 'throws when sf returns error' {
-        Mock -ModuleName 'psfdx-logs' Invoke-Sf { '{"status":1,"message":"failure"}' }
-        { Get-SalesforceLog -LogId 'X' -TargetOrg 'user' } | Should -Throw
+    InModuleScope 'psfdx-logs' {
+        BeforeEach {
+            # Default successful response from sf
+            $jsonOk = '{"status":0,"result":{"log":"LOGDATA"}}'
+            Mock Invoke-Sf { $jsonOk }
+        }
+        It 'requires either LogId or Last' {
+            { Get-SalesforceLog -TargetOrg 'user' } | Should -Throw
+        }
+        It 'fetches by LogId and returns log text' {
+            $log = Get-SalesforceLog -LogId '07Lxx0000000001' -TargetOrg 'user'
+            $log | Should -Be 'LOGDATA'
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log get --log-id 07Lxx0000000001 --target-org user --json' }
+        }
+        It 'uses -Last to get latest log id' {
+            $logs = @(
+                [pscustomobject]@{ Id = '2'; StartTime = [datetime]'2020-01-02' },
+                [pscustomobject]@{ Id = '1'; StartTime = [datetime]'2020-01-01' }
+            )
+            Mock Get-SalesforceLogs { $logs }
+            $null = Get-SalesforceLog -Last -TargetOrg 'user'
+            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -match '--log-id 2 ' }
+        }
+        It 'throws when sf returns error' {
+            Mock Invoke-Sf { '{"status":1,"message":"failure"}' }
+            { Get-SalesforceLog -LogId 'X' -TargetOrg 'user' } | Should -Throw
+        }
     }
 }
 
@@ -93,8 +83,10 @@ Describe 'Export-SalesforceLogs' {
             [pscustomobject]@{ Id = 'A'; StartTime = [datetime]'2020-01-01' },
             [pscustomobject]@{ Id = 'B'; StartTime = [datetime]'2020-01-02' }
         )
-        Mock -ModuleName 'psfdx-logs' Get-SalesforceLogs { $logs }
-        Mock -ModuleName 'psfdx-logs' Get-SalesforceLog { 'content' }
+        InModuleScope 'psfdx-logs' {
+            Mock Get-SalesforceLogs { $logs }
+            Mock Get-SalesforceLog { 'content' }
+        }
         # Avoid noisy progress in CI
         Mock Write-Progress {}
     }
@@ -115,7 +107,7 @@ Describe 'Export-SalesforceLogs' {
     }
 
     It 'handles no logs gracefully' {
-        Mock -ModuleName 'psfdx-logs' Get-SalesforceLogs { @() }
+        InModuleScope 'psfdx-logs' { Mock Get-SalesforceLogs { @() } }
         Export-SalesforceLogs -OutputFolder $script:tempDir -TargetOrg 'user' -Verbose | Out-Null
         (Get-ChildItem -Path $script:tempDir | Measure-Object).Count | Should -Be 0
     }
@@ -141,8 +133,8 @@ Describe 'Convert-SalesforceLog' {
 Describe 'Out-Notepad' {
     It 'creates a temp file and opens it (Windows only)' -Skip:(!$IsWindows) {
         # Mock Start-Process to prevent UI
-        Mock -ModuleName 'psfdx-logs' Start-Process {}
+        InModuleScope 'psfdx-logs' { Mock Start-Process {} }
         Out-Notepad -Content 'test'
-        Assert-MockCalled -ModuleName 'psfdx-logs' Start-Process -Times 1
+        InModuleScope 'psfdx-logs' { Assert-MockCalled Start-Process -Times 1 }
     }
 }

--- a/psfdx-logs/psfdx-logs.psd1
+++ b/psfdx-logs/psfdx-logs.psd1
@@ -22,7 +22,6 @@
 
     # Description of the functionality provided by this module
     Description       = 'PowerShell helpers for working with Salesforce DX (sf) Apex logs.'
-    CmdletNameChecking = $false
 
     # Minimum version of the PowerShell engine required by this module
     PowerShellVersion = '5.1'

--- a/psfdx-metadata/psfdx-metadata.Tests.ps1
+++ b/psfdx-metadata/psfdx-metadata.Tests.ps1
@@ -26,13 +26,13 @@ Describe 'Retrieve-SalesforceComponent' {
 Describe 'Describe-SalesforceObjects' {
     InModuleScope 'psfdx-metadata' {
         BeforeEach {
-            Mock Invoke-Sf { '{"status":0,"result":[{"xmlName":"ApexClass"}]}' }
-            Mock Show-SfResult { return @('Account','Contact') }
+            Mock -ModuleName 'psfdx-metadata' Invoke-Sf { '{"status":0,"result":[{"xmlName":"ApexClass"}]}' }
+            Mock -ModuleName 'psfdx-metadata' Show-SfResult { return @('Account','Contact') }
         }
         It 'passes category and returns Show-SfResult output' {
             $out = Describe-SalesforceObjects -TargetOrg 'me' -ObjectTypeCategory all
             $out | Should -Contain 'Account'
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -like 'sf sobject list * --category all*' }
+            Assert-MockCalled -ModuleName 'psfdx-metadata' Invoke-Sf -Times 1 -ParameterFilter { $Command -like 'sf sobject list * --category all*' }
         }
     }
 }

--- a/psfdx-metadata/psfdx-metadata.psd1
+++ b/psfdx-metadata/psfdx-metadata.psd1
@@ -7,7 +7,6 @@
     CompanyName           = 'psfdx'
     Copyright            = 'Copyright (c) psfdx contributors.'
     Description           = 'PowerShell helpers for retrieving, deploying, and describing Salesforce metadata.'
-    CmdletNameChecking    = $false
     PowerShellVersion     = '5.1'
     RequiredModules       = @()
     RequiredAssemblies    = @()

--- a/psfdx-packages/psfdx-packages.psd1
+++ b/psfdx-packages/psfdx-packages.psd1
@@ -7,7 +7,6 @@
     CompanyName           = 'psfdx'
     Copyright            = 'Copyright (c) psfdx contributors.'
     Description           = 'PowerShell helpers for Salesforce packages: list, create, version, promote, install.'
-    CmdletNameChecking    = $false
     PowerShellVersion     = '5.1'
     RequiredModules       = @()
     RequiredAssemblies    = @()

--- a/psfdx/psfdx.psd1
+++ b/psfdx/psfdx.psd1
@@ -4,7 +4,6 @@
     GUID = '2785d2bf-775f-4f2b-9d00-ee98f0163cf0'
     Author = 'Tony Ward'
     Description = 'PowerShell module that wraps Salesforce SFDX command line interface'
-    CmdletNameChecking = $false
     FunctionsToExport = '*'
     CmdletsToExport = @()
     AliasesToExport = @()


### PR DESCRIPTION
- Import each module manifest at discovery time so Pester discovery can resolve InModuleScope\n- Replace -ModuleName mocks with InModuleScope-scoped mocks/assertions\n- Applied to: psfdx-logs, psfdx-development, psfdx-packages, psfdx-metadata\n\nThis resolves discovery-time failures in CI and standardizes the test style.