### PR TITLE
feat(common): shared psfdx-common module for Invoke-Sf/Show-SfResult

### DIFF
--- a/install-linux.ps1
+++ b/install-linux.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 
 # Modules to install
 $modules = @(
+    'psfdx-common',
     'psfdx',
     'psfdx-logs',
     'psfdx-development',

--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -8,6 +8,7 @@ $ErrorActionPreference = 'Stop'
 
 # Modules to install
 $modules = @(
+    'psfdx-common',
     'psfdx',
     'psfdx-logs',
     'psfdx-development',

--- a/psfdx-common/psfdx-common.psd1
+++ b/psfdx-common/psfdx-common.psd1
@@ -1,0 +1,22 @@
+@{
+    RootModule            = 'psfdx-common.psm1'
+    ModuleVersion         = '0.1.0'
+    CompatiblePSEditions  = @('Desktop','Core')
+    GUID                  = 'f2c7e6e3-6a3c-4e0d-9f5a-4d3e2a1b9c01'
+    Author                = 'psfdx maintainers'
+    CompanyName           = 'psfdx'
+    Description           = 'Shared helpers for psfdx modules (Invoke-Sf, Show-SfResult).'
+    PowerShellVersion     = '5.1'
+    FunctionsToExport     = @('Invoke-Sf','Show-SfResult')
+    CmdletsToExport       = @()
+    VariablesToExport     = @()
+    AliasesToExport       = @()
+    PrivateData           = @{
+        PSData = @{
+            Tags        = @('Salesforce','SFDX','Common')
+            ProjectUri  = 'https://github.com/tonygward/psfdx'
+            ReleaseNotes = 'Initial shared helpers.'
+        }
+    }
+}
+

--- a/psfdx-common/psfdx-common.psm1
+++ b/psfdx-common/psfdx-common.psm1
@@ -1,0 +1,32 @@
+function Invoke-Sf {
+    [CmdletBinding(DefaultParameterSetName='String')]
+    Param(
+        [Parameter(ParameterSetName='String')][Alias('Arguments')][string] $StringCommand,
+        [Parameter(ParameterSetName='Array')][Alias('Command')][string[]] $ArrayCommand
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'Array') {
+        if (-not $ArrayCommand -or $ArrayCommand.Count -eq 0) { throw 'No command specified' }
+        Write-Verbose ($ArrayCommand -join ' ')
+        $exe = $ArrayCommand[0]
+        $args = @()
+        if ($ArrayCommand.Count -gt 1) { $args = $ArrayCommand[1..($ArrayCommand.Count-1)] }
+        return & $exe @args
+    }
+    if (-not $StringCommand) { throw 'No command specified' }
+    Write-Verbose $StringCommand
+    return Invoke-Expression -Command $StringCommand
+}
+
+function Show-SfResult {
+    [CmdletBinding()]
+    Param([Parameter(Mandatory = $true)][psobject] $Result)
+    $result = $Result | ConvertFrom-Json
+    if ($result.status -ne 0) {
+        Write-Debug $result
+        throw ($result.message)
+    }
+    return $result.result
+}
+
+Export-ModuleMember Invoke-Sf, Show-SfResult
+

--- a/psfdx-development/psfdx-development.psd1
+++ b/psfdx-development/psfdx-development.psd1
@@ -27,7 +27,7 @@
     PowerShellVersion = '5.1'
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules   = @()
+    RequiredModules   = @(@{ ModuleName = 'psfdx-common'; ModuleVersion = '0.1.0' })
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies = @()

--- a/psfdx-development/psfdx-development.psm1
+++ b/psfdx-development/psfdx-development.psm1
@@ -1,19 +1,19 @@
 function Invoke-Sf {
-    [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $Command)
-    Write-Verbose $Command
-    return Invoke-Expression -Command $Command
+    [CmdletBinding(DefaultParameterSetName='String')]
+    Param(
+        [Parameter(ParameterSetName='String')][Alias('Arguments')][string] $StringCommand,
+        [Parameter(ParameterSetName='Array')][Alias('Command')][string[]] $ArrayCommand
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'Array') {
+        return psfdx-common\Invoke-Sf -Command $ArrayCommand
+    }
+    return psfdx-common\Invoke-Sf -Arguments $StringCommand
 }
 
 function Show-SfResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
-    $result = $Result | ConvertFrom-Json
-    if ($result.status -ne 0) {
-        Write-Debug $result
-        throw ($result.message)
-    }
-    return $result.result
+    return psfdx-common\Show-SfResult -Result $Result
 }
 
 function Install-SalesforceLwcDevServer {

--- a/psfdx-logs/psfdx-logs.psd1
+++ b/psfdx-logs/psfdx-logs.psd1
@@ -27,7 +27,7 @@
     PowerShellVersion = '5.1'
 
     # Modules that must be imported into the global environment prior to importing this module
-    RequiredModules   = @()
+    RequiredModules   = @(@{ ModuleName = 'psfdx-common'; ModuleVersion = '0.1.0' })
 
     # Assemblies that must be loaded prior to importing this module
     RequiredAssemblies = @()

--- a/psfdx-logs/psfdx-logs.psm1
+++ b/psfdx-logs/psfdx-logs.psm1
@@ -1,23 +1,19 @@
 function Invoke-Sf {
-    [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string[]] $Command)
-    Write-Verbose ($Command -join ' ')
-    if ($Command.Length -eq 0) { throw 'No command specified' }
-    $exe = $Command[0]
-    $args = @()
-    if ($Command.Length -gt 1) { $args = $Command[1..($Command.Length-1)] }
-    return & $exe @args
+    [CmdletBinding(DefaultParameterSetName='Array')]
+    Param(
+        [Parameter(ParameterSetName='String')][Alias('Arguments')][string] $StringCommand,
+        [Parameter(ParameterSetName='Array')][Alias('Command')][string[]] $ArrayCommand
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'Array') {
+        return psfdx-common\Invoke-Sf -Command $ArrayCommand
+    }
+    return psfdx-common\Invoke-Sf -Arguments $StringCommand
 }
 
 function Show-SfResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
-    $result = $Result | ConvertFrom-Json
-    if ($result.status -ne 0) {
-        Write-Debug $result
-        throw ($result.message)
-    }
-    return $result.result
+    return psfdx-common\Show-SfResult -Result $Result
 }
 
 function Watch-SalesforceLogs {

--- a/psfdx-metadata/psfdx-metadata.psd1
+++ b/psfdx-metadata/psfdx-metadata.psd1
@@ -8,7 +8,7 @@
     Copyright            = 'Copyright (c) psfdx contributors.'
     Description           = 'PowerShell helpers for retrieving, deploying, and describing Salesforce metadata.'
     PowerShellVersion     = '5.1'
-    RequiredModules       = @()
+    RequiredModules       = @(@{ ModuleName = 'psfdx-common'; ModuleVersion = '0.1.0' })
     RequiredAssemblies    = @()
     ScriptsToProcess      = @()
     TypesToProcess        = @()

--- a/psfdx-metadata/psfdx-metadata.psm1
+++ b/psfdx-metadata/psfdx-metadata.psm1
@@ -1,19 +1,19 @@
 function Invoke-Sf {
-    [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $Command)
-    Write-Verbose $Command
-    return Invoke-Expression -Command $Command
+    [CmdletBinding(DefaultParameterSetName='String')]
+    Param(
+        [Parameter(ParameterSetName='String')][Alias('Arguments')][string] $StringCommand,
+        [Parameter(ParameterSetName='Array')][Alias('Command')][string[]] $ArrayCommand
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'Array') {
+        return psfdx-common\Invoke-Sf -Command $ArrayCommand
+    }
+    return psfdx-common\Invoke-Sf -Arguments $StringCommand
 }
 
 function Show-SfResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
-    $result = $Result | ConvertFrom-Json
-    if ($result.status -ne 0) {
-        Write-Debug $result
-        throw ($result.message)
-    }
-    return $result.result
+    return psfdx-common\Show-SfResult -Result $Result
 }
 
 function Retrieve-SalesforceOrg {

--- a/psfdx-packages/psfdx-packages.psd1
+++ b/psfdx-packages/psfdx-packages.psd1
@@ -8,7 +8,7 @@
     Copyright            = 'Copyright (c) psfdx contributors.'
     Description           = 'PowerShell helpers for Salesforce packages: list, create, version, promote, install.'
     PowerShellVersion     = '5.1'
-    RequiredModules       = @()
+    RequiredModules       = @(@{ ModuleName = 'psfdx-common'; ModuleVersion = '0.1.0' })
     RequiredAssemblies    = @()
     ScriptsToProcess      = @()
     TypesToProcess        = @()

--- a/psfdx-packages/psfdx-packages.psm1
+++ b/psfdx-packages/psfdx-packages.psm1
@@ -1,19 +1,19 @@
 function Invoke-Sf {
-    [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $Command)
-    Write-Verbose $Command
-    return Invoke-Expression -Command $Command
+    [CmdletBinding(DefaultParameterSetName='String')]
+    Param(
+        [Parameter(ParameterSetName='String')][Alias('Arguments')][string] $StringCommand,
+        [Parameter(ParameterSetName='Array')][Alias('Command')][string[]] $ArrayCommand
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'Array') {
+        return psfdx-common\Invoke-Sf -Command $ArrayCommand
+    }
+    return psfdx-common\Invoke-Sf -Arguments $StringCommand
 }
 
 function Show-SfResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
-    $result = $Result | ConvertFrom-Json
-    if ($result.status -ne 0) {
-        Write-Debug $result
-        throw ($result.message)
-    }
-    return $result.result
+    return psfdx-common\Show-SfResult -Result $Result
 }
 
 function Get-SalesforcePackages {

--- a/psfdx/psfdx.psd1
+++ b/psfdx/psfdx.psd1
@@ -5,6 +5,7 @@
     Author = 'Tony Ward'
     Description = 'PowerShell module that wraps Salesforce SFDX command line interface'
     FunctionsToExport = '*'
+    RequiredModules   = @(@{ ModuleName = 'psfdx-common'; ModuleVersion = '0.1.0' })
     CmdletsToExport = @()
     AliasesToExport = @()
 }

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -1,32 +1,19 @@
 function Invoke-Sf {
-    [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $Arguments)
-    Write-Verbose $Arguments
-    $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = "sf"
-    $psi.Arguments = $Arguments
-    $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError = $true
-    $psi.UseShellExecute = $false
-    $process = [System.Diagnostics.Process]::Start($psi)
-    $stdout = $process.StandardOutput.ReadToEnd()
-    $stderr = $process.StandardError.ReadToEnd()
-    $process.WaitForExit()
-    if ($process.ExitCode -ne 0 -and $stderr) {
-        Write-Debug $stderr
+    [CmdletBinding(DefaultParameterSetName='String')]
+    Param(
+        [Parameter(ParameterSetName='String')][Alias('Arguments')][string] $StringCommand,
+        [Parameter(ParameterSetName='Array')][Alias('Command')][string[]] $ArrayCommand
+    )
+    if ($PSCmdlet.ParameterSetName -eq 'Array') {
+        return psfdx-common\Invoke-Sf -Command $ArrayCommand
     }
-    return $stdout
+    return psfdx-common\Invoke-Sf -Arguments $StringCommand
 }
 
 function Show-SfResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
-    $result = $Result | ConvertFrom-Json
-    if ($result.status -ne 0) {
-        Write-Debug $result
-        throw ($result.message)
-    }
-    return $result.result
+    return psfdx-common\Show-SfResult -Result $Result
 }
 
 function Get-SalesforceDateTime {


### PR DESCRIPTION
Introduce psfdx-common to de-duplicate shared helpers and standardize CLI invocation.\n\nHighlights\n- New module: psfdx-common (exports Invoke-Sf, Show-SfResult)\n- All feature modules declare RequiredModules = psfdx-common\n- Per-module wrappers forward to psfdx-common (preserves existing test mocks)\n- Installers updated to include psfdx-common\n\nFollow-ups\n- We can gradually refactor modules to use array-based invocation everywhere and reduce string-based Invoke-Expression usage, now that common supports both.