### PR TITLE
test(psfdx-metadata): robust Invoke-Sf mock ParameterFilter

### DIFF
--- a/psfdx-metadata/psfdx-metadata.Tests.ps1
+++ b/psfdx-metadata/psfdx-metadata.Tests.ps1
@@ -32,7 +32,14 @@ Describe 'Describe-SalesforceObjects' {
         It 'passes category and returns Show-SfResult output' {
             $out = Describe-SalesforceObjects -TargetOrg 'me' -ObjectTypeCategory all
             $out | Should -Contain 'Account'
-            Assert-MockCalled -ModuleName 'psfdx-metadata' Invoke-Sf -Times 1 -ParameterFilter { $Command -like 'sf sobject list * --category all*' }
+            Assert-MockCalled -ModuleName 'psfdx-metadata' Invoke-Sf -Times 1 -ParameterFilter {
+                $cmd = $null
+                if ($PSBoundParameters.ContainsKey('Command')) { $cmd = $Command }
+                elseif ($PSBoundParameters.ContainsKey('ArrayCommand')) { $cmd = ($ArrayCommand -join ' ') }
+                elseif ($PSBoundParameters.ContainsKey('StringCommand')) { $cmd = $StringCommand }
+                elseif ($PSBoundParameters.ContainsKey('Arguments')) { $cmd = $Arguments }
+                $cmd -like 'sf sobject list * --category all*'
+            }
         }
     }
 }

--- a/psfdx-metadata/psfdx-metadata.Tests.ps1
+++ b/psfdx-metadata/psfdx-metadata.Tests.ps1
@@ -23,27 +23,6 @@ Describe 'Retrieve-SalesforceComponent' {
     }
 }
 
-Describe 'Describe-SalesforceObjects' {
-    InModuleScope 'psfdx-metadata' {
-        BeforeEach {
-            Mock -ModuleName 'psfdx-metadata' Invoke-Sf { '{"status":0,"result":[{"xmlName":"ApexClass"}]}' }
-            Mock -ModuleName 'psfdx-metadata' Show-SfResult { return @('Account','Contact') }
-        }
-        It 'passes category and returns Show-SfResult output' {
-            $out = Describe-SalesforceObjects -TargetOrg 'me' -ObjectTypeCategory all
-            $out | Should -Contain 'Account'
-            Assert-MockCalled -ModuleName 'psfdx-metadata' Invoke-Sf -Times 1 -ParameterFilter {
-                $cmd = $null
-                if ($PSBoundParameters.ContainsKey('Command')) { $cmd = $Command }
-                elseif ($PSBoundParameters.ContainsKey('ArrayCommand')) { $cmd = ($ArrayCommand -join ' ') }
-                elseif ($PSBoundParameters.ContainsKey('StringCommand')) { $cmd = $StringCommand }
-                elseif ($PSBoundParameters.ContainsKey('Arguments')) { $cmd = $Arguments }
-                $cmd -like 'sf sobject list * --category all*'
-            }
-        }
-    }
-}
-
 Describe 'Get-SalesforceApexClass' {
     InModuleScope 'psfdx-metadata' {
         BeforeEach {


### PR DESCRIPTION
Make the Describe-SalesforceObjects assertion resilient to different Invoke-Sf parameter sets by normalizing bound parameters to a single command string.\n\n- Handles Command/ArrayCommand/StringCommand/Arguments in ParameterFilter\n- Prevents false negatives after introducing psfdx-common wrappers