### PR TITLE
chore: make -TargetOrg optional where default org suffices

### DIFF
--- a/psfdx-logs/psfdx-logs.psm1
+++ b/psfdx-logs/psfdx-logs.psm1
@@ -50,14 +50,16 @@ function Get-SalesforceLog {
     Param(
         [Parameter(ParameterSetName='ById', Mandatory = $true)][string] $LogId,
         [Parameter(ParameterSetName='ByLast', Mandatory = $true)][switch] $Last,
-        [Parameter(Mandatory = $true)][string] $TargetOrg
+        [Parameter(Mandatory = $false)][string] $TargetOrg
     )
 
     if ($PSCmdlet.ParameterSetName -eq 'ByLast') {
         $LogId = (Get-SalesforceLogs -TargetOrg $TargetOrg | Sort-Object StartTime -Descending | Select-Object -First 1).Id
     }
 
-    $command = @('sf','apex','log','get','--log-id', $LogId, '--target-org', $TargetOrg, '--json')
+    $command = @('sf','apex','log','get','--log-id', $LogId)
+    if ($TargetOrg) { $command += @('--target-org', $TargetOrg) }
+    $command += @('--json')
     $raw = Invoke-Sf -Command $command
     $parsed = Show-SfResult -Result $raw
     return $parsed.log
@@ -68,7 +70,7 @@ function Export-SalesforceLogs {
     Param(
         [Parameter(Mandatory = $false)][int] $Limit = 50,
         [Parameter(Mandatory = $false)][string] $OutputFolder = $null,
-        [Parameter(Mandatory = $true)][string] $TargetOrg
+        [Parameter(Mandatory = $false)][string] $TargetOrg
     )
 
     if (($OutputFolder -eq $null) -or ($OutputFolder -eq "") ) {

--- a/psfdx-packages/psfdx-packages.psm1
+++ b/psfdx-packages/psfdx-packages.psm1
@@ -229,14 +229,14 @@ function Install-SalesforcePackageVersion {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)][string] $PackageVersionId,
-        [Parameter(Mandatory = $true)][Alias('Username','DevHubUsername')][string] $TargetOrg,
+        [Parameter(Mandatory = $false)][Alias('Username','DevHubUsername')][string] $TargetOrg,
         [Parameter(Mandatory = $false)][switch] $NoPrompt,
         [Parameter(Mandatory = $false)][int] $WaitMinutes = 10
     )
 
     $command = "sf package install"
     $command += " --package $PackageVersionId"
-    $command += " --target-org $TargetOrg"
+    if ($TargetOrg) { $command += " --target-org $TargetOrg" }
     if ($NoPrompt) {
         $command += " --no-prompt"
     }

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -162,14 +162,17 @@ function Remove-SalesforceAlias {
 
 function Get-SalesforceLimits {
     [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $TargetOrg)
-    $result = Invoke-Sf -Arguments "limits api display --target-org $TargetOrg --json"
+    Param([Parameter(Mandatory = $false)][string] $TargetOrg)
+    $arguments = "limits api display"
+    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
+    $arguments += " --json"
+    $result = Invoke-Sf -Arguments $arguments
     return Show-SfResult -Result $result
 }
 
 function Get-SalesforceDataStorage {
     [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $TargetOrg)
+    Param([Parameter(Mandatory = $false)][string] $TargetOrg)
     $values = Get-SalesforceLimits -TargetOrg $TargetOrg | Where-Object Name -eq "DataStorageMB"
     $values | Add-Member -NotePropertyName InUse -NotePropertyValue ($values.max + ($values.remaining * -1))
     $values | Add-Member -NotePropertyName Usage -NotePropertyValue (($values.max + ($values.remaining * -1)) / $values.max).ToString('P')
@@ -178,7 +181,7 @@ function Get-SalesforceDataStorage {
 
 function Get-SalesforceApiUsage {
     [CmdletBinding()]
-    Param([Parameter(Mandatory = $true)][string] $TargetOrg)
+    Param([Parameter(Mandatory = $false)][string] $TargetOrg)
     $values = Get-SalesforceLimits -TargetOrg $TargetOrg | Where-Object Name -eq "DailyApiRequests"
     $values | Add-Member -NotePropertyName Usage -NotePropertyValue (($values.max + ($values.remaining * -1)) / $values.max).ToString('P')
     return $values
@@ -230,7 +233,7 @@ function New-SalesforceObject {
     Param(
         [Parameter(Mandatory = $true)][string] $Type,
         [Parameter(Mandatory = $true)][string] $FieldUpdates,
-        [Parameter(Mandatory = $true)][string] $TargetOrg,
+        [Parameter(Mandatory = $false)][string] $TargetOrg,
         [Parameter(Mandatory = $false)][switch] $UseToolingApi
     )
     Write-Verbose $FieldUpdates
@@ -238,7 +241,7 @@ function New-SalesforceObject {
     $arguments += " --sobject $Type"
     $arguments += " --values `"$FieldUpdates`""
     if ($UseToolingApi) { $arguments += " --use-tooling-api" }
-    $arguments += " --target-org $TargetOrg"
+    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
     $result = Invoke-Sf -Arguments $arguments
     return Show-SfResult -Result $result
@@ -266,7 +269,7 @@ function Set-SalesforceObject {
         [Parameter(Mandatory = $true)][string] $Id,
         [Parameter(Mandatory = $true)][string] $Type,
         [Parameter(Mandatory = $true)][string] $FieldUpdates,
-        [Parameter(Mandatory = $true)][string] $TargetOrg,
+        [Parameter(Mandatory = $false)][string] $TargetOrg,
         [Parameter(Mandatory = $false)][switch] $UseToolingApi
     )
     Write-Verbose $FieldUpdates
@@ -275,7 +278,7 @@ function Set-SalesforceObject {
     $arguments += " --record-id $Id"
     $arguments += " --values `"$FieldUpdates`""
     if ($UseToolingApi) { $arguments += " --use-tooling-api" }
-    $arguments += " --target-org $TargetOrg"
+    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
     $result = Invoke-Sf -Arguments $arguments
     return Show-SfResult -Result $result
@@ -285,7 +288,7 @@ function Get-SalesforceRecordType {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)][string] $ObjectType,
-        [Parameter(Mandatory = $true)][string] $TargetOrg
+        [Parameter(Mandatory = $false)][string] $TargetOrg
     )
     $query = "SELECT Id, SobjectType, Name, DeveloperName, IsActive, IsPersonType"
     $query += " FROM RecordType"
@@ -298,9 +301,12 @@ function Invoke-SalesforceApexFile {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)][string] $ApexFile,
-        [Parameter(Mandatory = $true)][string] $TargetOrg
+        [Parameter(Mandatory = $false)][string] $TargetOrg
     )
-    $result = Invoke-Sf -Arguments "apex run --file $ApexFile --target-org $TargetOrg --json"
+    $arguments = "apex run --file $ApexFile"
+    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
+    $arguments += " --json"
+    $result = Invoke-Sf -Arguments $arguments
     return Show-SfResult -Result $result
 }
 


### PR DESCRIPTION
This PR makes -TargetOrg optional for commands that can safely use the sf default org.\n\nChanges\n- psfdx: optional -TargetOrg for limits, storage, API usage, New/Set-SalesforceObject, Get-SalesforceRecordType, Invoke-SalesforceApexFile.\n- psfdx-logs: optional -TargetOrg for Get-SalesforceLog and Export-SalesforceLogs.\n- psfdx-packages: optional -TargetOrg for Install-SalesforcePackageVersion.\n\nNotes\n- Kept -TargetOrg mandatory where inherently required (e.g., JWT auth, REST password grant, project user set).\n- Only append --target-org when provided; otherwise CLI default org applies.