### PR TITLE
feat(psfdx): rename Set-SalesforceObject to Set-SalesforceRecord

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,14 @@ Other psfdx commands require a target org (username or alias).
 **2. Retrieve first 10 Salesforce Accounts**
 ```
 Import-Module psfdx
-Select-SalesforceObjects -Query "SELECT Id,Name FROM Account LIMIT 10" -TargetOrg my@email.com
+Select-SalesforceRecords -Query "SELECT Id,Name FROM Account LIMIT 10" -TargetOrg my@email.com
 ```
 NB you only need to Import-Module psfdx once per PowerShell session
 
 **3. Create and use a Salesforce Alias**
 ```
 Add-SalesforceAlias -TargetOrg my@email.com -Alias myalias
-Select-SalesforceObjects -Query "SELECT Id,Name FROM Account LIMIT 10" -TargetOrg myalias
+Select-SalesforceRecords -Query "SELECT Id,Name FROM Account LIMIT 10" -TargetOrg myalias
 ```
 
 **4. Retrieve every psfdx cmdlet**
@@ -59,7 +59,7 @@ Get-Command -Module psfdx
 * `Get-SalesforceConnections` - List connected orgs
 * `Repair-SalesforceConnections` - Clean up stale connections
 ### Record Operations
-* `Select-SalesforceObjects` - SOQL queries with flexible output formats
+* `Select-SalesforceRecords` - SOQL queries with flexible output formats
 * `New-SalesforceObject` - Create records
 * `Set-SalesforceObject` - Update records
 * `Get-SalesforceRecordType` - Retrieve record type metadata

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Get-Command -Module psfdx
 * `Repair-SalesforceConnections` - Clean up stale connections
 ### Record Operations
 * `Select-SalesforceRecords` - SOQL queries with flexible output formats
-* `New-SalesforceObject` - Create records
+* `New-SalesforceRecord` - Create records
 * `Set-SalesforceObject` - Update records
 * `Get-SalesforceRecordType` - Retrieve record type metadata
 ### Org Management

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Get-Command -Module psfdx
 ### Record Operations
 * `Select-SalesforceRecords` - SOQL queries with flexible output formats
 * `New-SalesforceRecord` - Create records
-* `Set-SalesforceObject` - Update records
+* `Set-SalesforceRecord` - Update records
 * `Get-SalesforceRecordType` - Retrieve record type metadata
 ### Org Management
 * `Open-Salesforce` - Open org in browser

--- a/psfdx/psfdx.Tests.ps1
+++ b/psfdx/psfdx.Tests.ps1
@@ -82,12 +82,12 @@ Describe 'psfdx module' {
                 $res.id | Should -Be '001xx0000000001'
             }
 
-            It 'returns parsed result for Set-SalesforceObject' {
+            It 'returns parsed result for Set-SalesforceRecord' {
                 $json = @'
 {"status":0,"result":{"success":true}}
 '@
                 Mock Invoke-Sf { $json } -ModuleName $module.Name
-                $res = Set-SalesforceObject -Id '001xx0000000001' -Type Account -FieldUpdates 'Name=Updated' -TargetOrg me
+                $res = Set-SalesforceRecord -Id '001xx0000000001' -Type Account -FieldUpdates 'Name=Updated' -TargetOrg me
                 $res.success | Should -BeTrue
             }
         }

--- a/psfdx/psfdx.Tests.ps1
+++ b/psfdx/psfdx.Tests.ps1
@@ -73,12 +73,12 @@ Describe 'psfdx module' {
         }
 
         Context 'Object CRUD helpers' {
-            It 'returns parsed result for New-SalesforceObject' {
+            It 'returns parsed result for New-SalesforceRecord' {
                 $json = @'
 {"status":0,"result":{"id":"001xx0000000001"}}
 '@
                 Mock Invoke-Sf { $json } -ModuleName $module.Name
-                $res = New-SalesforceObject -Type Account -FieldUpdates 'Name=Acme' -TargetOrg me
+                $res = New-SalesforceRecord -Type Account -FieldUpdates 'Name=Acme' -TargetOrg me
                 $res.id | Should -Be '001xx0000000001'
             }
 

--- a/psfdx/psfdx.Tests.ps1
+++ b/psfdx/psfdx.Tests.ps1
@@ -60,13 +60,13 @@ Describe 'psfdx module' {
             }
         }
 
-        Context 'Select-SalesforceObjects' {
+        Context 'Select-SalesforceRecords' {
             It 'returns records from successful JSON result' {
                 $json = @'
 {"status":0,"result":{"records":[{"Id":"001xx0000000001"}]}}
 '@
                 Mock Invoke-Sf { $json } -ModuleName $module.Name
-                $rows = Select-SalesforceObjects -Query 'SELECT Id FROM Account LIMIT 1' -TargetOrg 'me'
+                $rows = Select-SalesforceRecords -Query 'SELECT Id FROM Account LIMIT 1' -TargetOrg 'me'
                 $rows.Count | Should -Be 1
                 $rows[0].Id | Should -Be '001xx0000000001'
             }

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -226,9 +226,9 @@ Target org username or alias.
 .PARAMETER UseToolingApi
 Use the Salesforce Tooling API for the request.
 .EXAMPLE
-New-SalesforceObject -Type Account -FieldUpdates 'Name=Acme' -TargetOrg me@example.com -UseToolingApi
+New-SalesforceRecord -Type Account -FieldUpdates 'Name=Acme' -TargetOrg me@example.com -UseToolingApi
 #>
-function New-SalesforceObject {
+function New-SalesforceRecord {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)][string] $Type,
@@ -388,7 +388,7 @@ Export-ModuleMember Get-SalesforceApiUsage
 
 Export-ModuleMember Select-SalesforceRecords
 
-Export-ModuleMember New-SalesforceObject
+Export-ModuleMember New-SalesforceRecord
 Export-ModuleMember Set-SalesforceObject
 Export-ModuleMember Get-SalesforceRecordType
 

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -187,7 +187,7 @@ function Get-SalesforceApiUsage {
     return $values
 }
 
-function Select-SalesforceObjects {
+function Select-SalesforceRecords {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $false)][string] $Query,
@@ -293,7 +293,7 @@ function Get-SalesforceRecordType {
     $query = "SELECT Id, SobjectType, Name, DeveloperName, IsActive, IsPersonType"
     $query += " FROM RecordType"
     if ($ObjectType) { $query += " WHERE SobjectType = '$ObjectType'" }
-    $results = Select-SalesforceObjects -Query $query -TargetOrg $TargetOrg
+    $results = Select-SalesforceRecords -Query $query -TargetOrg $TargetOrg
     return $results | Select-Object Id, SobjectType, Name, DeveloperName, IsActive, IsPersonType
 }
 
@@ -386,7 +386,7 @@ Export-ModuleMember Get-SalesforceLimits
 Export-ModuleMember Get-SalesforceDataStorage
 Export-ModuleMember Get-SalesforceApiUsage
 
-Export-ModuleMember Select-SalesforceObjects
+Export-ModuleMember Select-SalesforceRecords
 
 Export-ModuleMember New-SalesforceObject
 Export-ModuleMember Set-SalesforceObject

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -261,9 +261,9 @@ Target org username or alias.
 .PARAMETER UseToolingApi
 Use the Salesforce Tooling API for the request.
 .EXAMPLE
-Set-SalesforceObject -Id 001xx000003DGbV -Type Account -FieldUpdates 'Name=Updated' -TargetOrg me@example.com -UseToolingApi
+Set-SalesforceRecord -Id 001xx000003DGbV -Type Account -FieldUpdates 'Name=Updated' -TargetOrg me@example.com -UseToolingApi
 #>
-function Set-SalesforceObject {
+function Set-SalesforceRecord {
     [CmdletBinding()]
     Param(
         [Parameter(Mandatory = $true)][string] $Id,
@@ -389,7 +389,7 @@ Export-ModuleMember Get-SalesforceApiUsage
 Export-ModuleMember Select-SalesforceRecords
 
 Export-ModuleMember New-SalesforceRecord
-Export-ModuleMember Set-SalesforceObject
+Export-ModuleMember Set-SalesforceRecord
 Export-ModuleMember Get-SalesforceRecordType
 
 Export-ModuleMember Invoke-SalesforceApexFile


### PR DESCRIPTION
Renames the record update helper for clarity and consistency.\n\nChanges\n- psfdx/psfdx.psm1: function renamed to Set-SalesforceRecord, export updated.\n- psfdx/psfdx.Tests.ps1: tests updated to call Set-SalesforceRecord.\n- README: command reference updated.\n\nOptional: I can add a compatibility alias so Set-SalesforceObject continues to work for existing scripts.