### PR TITLE
Use PSModulePath for current user install

### DIFF
--- a/install-windows.ps1
+++ b/install-windows.ps1
@@ -18,7 +18,12 @@ $modules = @(
 if ($Scope -eq 'AllUsers') {
     $dest = Join-Path -Path $PSHOME -ChildPath 'Modules'
 } else {
-    $dest = Join-Path -Path $HOME -ChildPath 'Documents/PowerShell/Modules'
+    $dest = $env:PSModulePath -split [System.IO.Path]::PathSeparator |
+        Where-Object { $_.StartsWith($HOME, [System.StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object -First 1
+    if (-not $dest) {
+        $dest = Join-Path -Path $HOME -ChildPath 'Documents/PowerShell/Modules'
+    }
 }
 
 if (-not (Test-Path -Path $dest)) {


### PR DESCRIPTION
## Summary
- Select module destination from PSModulePath for current user scope

## Testing
- `pwsh -NoLogo -NoProfile -Command '$env:PSModulePath'` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be7c2090908324aaa5d9cdbd67be4d