### PR TITLE
Rename Invoke-Sf to Invoke-Salesforce

### DIFF
--- a/psfdx-development/psfdx-development.Tests.ps1
+++ b/psfdx-development/psfdx-development.Tests.ps1
@@ -4,24 +4,24 @@ Import-Module $moduleManifest -Force | Out-Null
 
 Describe 'psfdx-development basics' {
     InModuleScope 'psfdx-development' {
-        BeforeEach { Mock Invoke-Sf {} }
+        BeforeEach { Mock Invoke-Salesforce {} }
         It 'starts LWC dev server with sf command' {
             Start-SalesforceLwcDevServer | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -eq 'sf lightning lwc start' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Command -eq 'sf lightning lwc start' }
         }
         It 'sets project user with equals syntax' {
             Set-SalesforceProjectUser -TargetOrg 'user@example' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -eq 'sf config set target-org=user@example' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Command -eq 'sf config set target-org=user@example' }
         }
     }
 }
 
 Describe 'Test-Salesforce command building' {
     InModuleScope 'psfdx-development' {
-        BeforeEach { Mock Invoke-Sf { '{"status":0,"result":{"tests":[],"summary":{"outcome":"Passed","testRunCoverage":"100%"}}}' } }
+        BeforeEach { Mock Invoke-Salesforce { '{"status":0,"result":{"tests":[],"summary":{"outcome":"Passed","testRunCoverage":"100%"}}}' } }
         It 'runs specified class synchronously with target org and json' {
             Test-Salesforce -ClassName 'MyClass' -TargetOrg 'me' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -like 'sf apex run test *') -and ($Command -like '* --class-names MyClass*') -and ($Command -like '* --target-org me*') -and ($Command -like '* --result-format json*') }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -like 'sf apex run test *') -and ($Command -like '* --class-names MyClass*') -and ($Command -like '* --target-org me*') -and ($Command -like '* --result-format json*') }
         }
     }
 }

--- a/psfdx-development/psfdx-development.psm1
+++ b/psfdx-development/psfdx-development.psm1
@@ -1,4 +1,4 @@
-function Invoke-Sf {
+function Invoke-Salesforce {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Command)
     Write-Verbose $Command
@@ -19,15 +19,15 @@ function Show-SfResult {
 function Install-SalesforceLwcDevServer {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Command "npm install -g node-gyp"
-    Invoke-Sf -Command "sf plugins install @salesforce/lwc-dev-server"
-    Invoke-Sf -Command "sf plugins update"
+    Invoke-Salesforce -Command "npm install -g node-gyp"
+    Invoke-Salesforce -Command "sf plugins install @salesforce/lwc-dev-server"
+    Invoke-Salesforce -Command "sf plugins update"
 }
 
 function Start-SalesforceLwcDevServer {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Command "sf lightning lwc start"
+    Invoke-Salesforce -Command "sf lightning lwc start"
 }
 
 function Set-SalesforceDefaultDevHub {
@@ -35,20 +35,20 @@ function Set-SalesforceDefaultDevHub {
     Param(
         [Parameter(Mandatory = $true)][string] $DevhubUsername
     )
-    Invoke-Sf -Command "sf config set target-dev-hub=$DevhubUsername --global"
+    Invoke-Salesforce -Command "sf config set target-dev-hub=$DevhubUsername --global"
 }
 
 function Remove-SalesforceDefaultDevHub {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Command "sf config unset target-dev-hub --global"
+    Invoke-Salesforce -Command "sf config unset target-dev-hub --global"
 }
 
 function Get-SalesforceConfig {
     [CmdletBinding()]
     Param()
     $command = "sf config list --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     Show-SfResult -Result $result
 }
 
@@ -64,7 +64,7 @@ function Get-SalesforceScratchOrgs {
         $command += " --skip-connection-status"
     }
     $command += " --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
 
     $result = $result | ConvertFrom-Json
     $result = $result.result.scratchOrgs
@@ -97,7 +97,7 @@ function New-SalesforceScratchOrg {
     }
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     Show-SfResult -Result $result
 
     $scratchOrgUsername = $result.username
@@ -116,7 +116,7 @@ function Remove-SalesforceScratchOrg {
     if ($NoPrompt) {
         $command += " --no-prompt"
     }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Remove-SalesforceScratchOrgs {
@@ -159,7 +159,7 @@ function New-SalesforceProject {
     $command += " --template $Template"
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     $result = Show-SfResult -Result $result
 
     if (($null -ne $DefaultUserName) -and ($DefaultUserName -ne '')) {
@@ -282,7 +282,7 @@ function Get-SalesforceProjectUser {
 function Set-SalesforceProjectUser {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $TargetOrg)
-    Invoke-Sf -Command "sf config set target-org=$TargetOrg"
+    Invoke-Salesforce -Command "sf config set target-org=$TargetOrg"
 }
 
 function DeployAndTest-SalesforceApex {
@@ -298,7 +298,7 @@ function DeployAndTest-SalesforceApex {
     $command += " --test-level RunSpecifiedTests"
     $command += " --tests $TestClassName"
 
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Test-Salesforce {
@@ -345,7 +345,7 @@ function Test-Salesforce {
     if ($TargetOrg) { $command += " --target-org $TargetOrg" }
     $command += " --result-format $ResultFormat"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     $result = $result | ConvertFrom-Json
 
     Write-Verbose $result
@@ -380,7 +380,7 @@ function Get-SalesforceCodeCoverage {
         $query += "WHERE ApexClassOrTriggerId = '$apexClassId' "
     }
 
-    $result = Invoke-Sf -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
+    $result = Invoke-Salesforce -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
     $result = $result | ConvertFrom-Json
     if ($result.status -ne 0) {
         throw ($result.message)
@@ -419,7 +419,7 @@ function Get-SalesforceApexClass {
         [Parameter(Mandatory = $true)][string] $TargetOrg
     )
     $query = "SELECT Id, Name FROM ApexClass WHERE Name = '$Name' LIMIT 1"
-    $result = Invoke-Sf -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
+    $result = Invoke-Salesforce -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
     $parsed = $result | ConvertFrom-Json
     if ($parsed.status -ne 0) {
         throw ($parsed.message)
@@ -431,9 +431,9 @@ function Install-SalesforceJest {
     [CmdletBinding()]
     Param()
     if (Get-Command yarn -ErrorAction SilentlyContinue) {
-        Invoke-Sf -Command "yarn add -D @salesforce/sfdx-lwc-jest"
+        Invoke-Salesforce -Command "yarn add -D @salesforce/sfdx-lwc-jest"
     } else {
-        Invoke-Sf -Command "npm install -D @salesforce/sfdx-lwc-jest"
+        Invoke-Salesforce -Command "npm install -D @salesforce/sfdx-lwc-jest"
     }
 }
 
@@ -442,26 +442,26 @@ function New-SalesforceJestTest {
     Param([Parameter(Mandatory = $true)][string] $LwcName)
     $filePath = "force-app/main/default/lwc/$LwcName/$LwcName.js"
     $command = "sf force lightning lwc test create --filepath $filePath --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
 function Test-SalesforceJest {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Command "npm run test:unit"
+    Invoke-Salesforce -Command "npm run test:unit"
 }
 
 function Debug-SalesforceJest {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Command "npm run test:unit:debug"
+    Invoke-Salesforce -Command "npm run test:unit:debug"
 }
 
 function Watch-SalesforceJest {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Command "npm run test:unit:watch"
+    Invoke-Salesforce -Command "npm run test:unit:watch"
 }
 
 function Deploy-SalesforceComponent {
@@ -478,7 +478,7 @@ function Deploy-SalesforceComponent {
     $command += " --targetusername $TargetOrg"
     $command += " --json"
 
-    $response = Invoke-Sf -Command $command | ConvertFrom-Json
+    $response = Invoke-Salesforce -Command $command | ConvertFrom-Json
     if ($response.result.success -ne $true) {
         Write-Verbose $result
         throw ("Failed to Deploy ")
@@ -586,7 +586,7 @@ function Push-Salesforce {
 
     if ($Test) { $command += " --test-level RunLocalTests" }
 
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Pull-Salesforce {
@@ -603,7 +603,7 @@ function Pull-Salesforce {
     if ($PackageNames) { $command += " --package-name $PackageNames"}
     if ($IgnoreConflicts) { $command += " --ignore-conflicts"}
     if ($IgnoreWarnings) { $command += " --ignore-warnings"}
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function New-SalesforceApexClass {
@@ -626,7 +626,7 @@ function New-SalesforceApexClass {
     if ($OutputDirectory) {
         $command += " --output-dir $OutputDirectory"
     }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function New-SalesforceApexTrigger {
@@ -652,5 +652,5 @@ function New-SalesforceApexTrigger {
     if ($OutputDirectory) {
         $command += " --output-dir $OutputDirectory"
     }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }

--- a/psfdx-logs/psfdx-logs.Tests.ps1
+++ b/psfdx-logs/psfdx-logs.Tests.ps1
@@ -4,22 +4,22 @@ Import-Module $moduleManifest -Force | Out-Null
 
 Describe 'Watch-SalesforceLogs' {
     InModuleScope 'psfdx-logs' {
-        BeforeEach { Mock Invoke-Sf {} }
+        BeforeEach { Mock Invoke-Salesforce {} }
         It 'builds base command with color' {
             Watch-SalesforceLogs | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --color' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --color' }
         }
         It 'adds username when provided' {
             Watch-SalesforceLogs -TargetOrg 'user@example' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --target-org user@example --color' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --target-org user@example --color' }
         }
         It 'adds skip trace flag' {
             Watch-SalesforceLogs -SkipTraceFlag | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --skip-trace-flag --color' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --skip-trace-flag --color' }
         }
         It 'adds debug level when provided' {
             Watch-SalesforceLogs -DebugLevel 'SFDC_DevConsole' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --debug-level SFDC_DevConsole --color' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log tail --debug-level SFDC_DevConsole --color' }
         }
     }
 }
@@ -27,18 +27,18 @@ Describe 'Watch-SalesforceLogs' {
 Describe 'Get-SalesforceLogs' {
     InModuleScope 'psfdx-logs' {
         BeforeEach {
-            Mock Invoke-Sf { '{"status":0,"result":[{"Id":"1"}]}' }
+            Mock Invoke-Salesforce { '{"status":0,"result":[{"Id":"1"}]}' }
             Mock Show-SfResult { return @(@{ Id = '1' }) }
         }
         It 'lists logs with json' {
             $out = Get-SalesforceLogs
             $out | Should -Not -BeNullOrEmpty
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --json' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --json' }
             Assert-MockCalled Show-SfResult -Times 1
         }
         It 'adds username when provided' {
             Get-SalesforceLogs -TargetOrg 'user@example' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --target-org user@example --json' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --target-org user@example --json' }
         }
     }
 }
@@ -48,7 +48,7 @@ Describe 'Get-SalesforceLog' {
         BeforeEach {
             # Default successful response from sf
             $jsonOk = '{"status":0,"result":{"log":"LOGDATA"}}'
-            Mock Invoke-Sf { $jsonOk }
+            Mock Invoke-Salesforce { $jsonOk }
         }
         It 'requires either LogId or Last' {
             { Get-SalesforceLog -TargetOrg 'user' } | Should -Throw
@@ -56,7 +56,7 @@ Describe 'Get-SalesforceLog' {
         It 'fetches by LogId and returns log text' {
             $log = Get-SalesforceLog -LogId '07Lxx0000000001' -TargetOrg 'user'
             $log | Should -Be 'LOGDATA'
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log get --log-id 07Lxx0000000001 --target-org user --json' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log get --log-id 07Lxx0000000001 --target-org user --json' }
         }
         It 'uses -Last to get latest log id' {
             $logs = @(
@@ -65,10 +65,10 @@ Describe 'Get-SalesforceLog' {
             )
             Mock Get-SalesforceLogs { $logs }
             $null = Get-SalesforceLog -Last -TargetOrg 'user'
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -join ' ') -match '--log-id 2 ' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -match '--log-id 2 ' }
         }
         It 'throws when sf returns error' {
-            Mock Invoke-Sf { '{"status":1,"message":"failure"}' }
+            Mock Invoke-Salesforce { '{"status":1,"message":"failure"}' }
             { Get-SalesforceLog -LogId 'X' -TargetOrg 'user' } | Should -Throw
         }
     }

--- a/psfdx-logs/psfdx-logs.psm1
+++ b/psfdx-logs/psfdx-logs.psm1
@@ -1,4 +1,4 @@
-function Invoke-Sf {
+function Invoke-Salesforce {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string[]] $Command)
     Write-Verbose ($Command -join ' ')
@@ -32,7 +32,7 @@ function Watch-SalesforceLogs {
     if ($SkipTraceFlag) { $command += @('--skip-trace-flag') }
     if ($DebugLevel) { $command += @('--debug-level', $DebugLevel) }
     $command += @('--color')
-    return Invoke-Sf -Command $command
+    return Invoke-Salesforce -Command $command
 }
 
 function Get-SalesforceLogs {
@@ -41,7 +41,7 @@ function Get-SalesforceLogs {
     $command = @('sf','apex','log','list')
     if ($TargetOrg) { $command += @('--target-org', $TargetOrg) }
     $command += @('--json')
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -60,7 +60,7 @@ function Get-SalesforceLog {
     $command = @('sf','apex','log','get','--log-id', $LogId)
     if ($TargetOrg) { $command += @('--target-org', $TargetOrg) }
     $command += @('--json')
-    $raw = Invoke-Sf -Command $command
+    $raw = Invoke-Salesforce -Command $command
     $parsed = Show-SfResult -Result $raw
     return $parsed.log
 }

--- a/psfdx-metadata/psfdx-metadata.Tests.ps1
+++ b/psfdx-metadata/psfdx-metadata.Tests.ps1
@@ -4,21 +4,21 @@ Import-Module $moduleManifest -Force | Out-Null
 
 Describe 'Retrieve-SalesforceOrg' {
     InModuleScope 'psfdx-metadata' {
-        BeforeEach { Mock Invoke-Sf {} }
+        BeforeEach { Mock Invoke-Salesforce {} }
         It 'creates manifest from org and retrieves via manifest' {
             Retrieve-SalesforceOrg -TargetOrg 'user' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -like 'sf force source manifest create --from-org user*' }
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -like 'sf project retrieve start --target-org user*' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Command -like 'sf force source manifest create --from-org user*' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Command -like 'sf project retrieve start --target-org user*' }
         }
     }
 }
 
 Describe 'Retrieve-SalesforceComponent' {
     InModuleScope 'psfdx-metadata' {
-        BeforeEach { Mock Invoke-Sf {} }
+        BeforeEach { Mock Invoke-Salesforce {} }
         It 'retrieves a named ApexClass for target org' {
             Retrieve-SalesforceComponent -Type ApexClass -Name 'MyClass' -TargetOrg 'me' | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -eq 'sf project retrieve start --metadata ApexClass:MyClass --target-org me' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Command -eq 'sf project retrieve start --metadata ApexClass:MyClass --target-org me' }
         }
     }
 }
@@ -27,7 +27,7 @@ Describe 'Get-SalesforceApexClass' {
     InModuleScope 'psfdx-metadata' {
         BeforeEach {
             $json = '{"status":0,"result":{"records":[{"Id":"01pxx0000000001AAA","Name":"MyClass"}]}}'
-            Mock Invoke-Sf { $json }
+            Mock Invoke-Salesforce { $json }
         }
         It 'returns first record by name' {
             $rec = Get-SalesforceApexClass -Name 'MyClass' -TargetOrg 'me'

--- a/psfdx-metadata/psfdx-metadata.psm1
+++ b/psfdx-metadata/psfdx-metadata.psm1
@@ -1,4 +1,4 @@
-function Invoke-Sf {
+function Invoke-Salesforce {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Command)
     Write-Verbose $Command
@@ -27,11 +27,11 @@ function Retrieve-SalesforceOrg {
     $command += " --name=allMetadata"
     $command += " --output-dir ."
     if ($IncludePackages) { $command += " --include-packages=unlocked" }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 
     $command = "sf project retrieve start --target-org $TargetOrg"
     $command += " --manifest allMetadata.xml"
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Retrieve-SalesforceComponent {
@@ -228,7 +228,7 @@ function Retrieve-SalesforceComponent {
     $command = "sf project retrieve start --metadata $Type"
     if ($Name) { $command += ":$Name" }
     if ($TargetOrg) { $command += " --target-org $TargetOrg" }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Retrieve-SalesforceField {
@@ -239,7 +239,7 @@ function Retrieve-SalesforceField {
         [Parameter(Mandatory = $false)][string] $TargetOrg)
     $command = "sf project retrieve start --metadata CustomField:$ObjectName.$FieldName"
     if ($TargetOrg) { $command += " --target-org $TargetOrg" }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Retrieve-SalesforceValidationRule {
@@ -250,7 +250,7 @@ function Retrieve-SalesforceValidationRule {
         [Parameter(Mandatory = $false)][string] $TargetOrg)
     $command = "sf project retrieve start --metadata ValidationRule:$ObjectName.$RuleName"
     if ($TargetOrg) { $command += " --target-org $TargetOrg" }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 
 function Deploy-SalesforceComponent {
@@ -451,7 +451,7 @@ function Deploy-SalesforceComponent {
     $command += " --target-org $TargetOrg"
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -465,7 +465,7 @@ function Describe-SalesforceObjects {
     $command += " --category $ObjectTypeCategory"
     $command += " --target-org $TargetOrg"
     $command += " --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -485,7 +485,7 @@ function Describe-SalesforceObject {
         $command += " --use-tooling-api"
     }
     $command += " --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -509,7 +509,7 @@ function Get-SalesforceMetaTypes {
     $command += " --target-org $TargetOrg"
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     $result = $result | ConvertFrom-Json
     $result = $result.result.metadataObjects
     $result = $result | Select-Object xmlName
@@ -523,7 +523,7 @@ function Get-SalesforceApexClass {
         [Parameter(Mandatory = $true)][string] $TargetOrg
     )
     $query = "SELECT Id, Name FROM ApexClass WHERE Name = '$Name' LIMIT 1"
-    $result = Invoke-Sf -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
+    $result = Invoke-Salesforce -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
     $parsed = $result | ConvertFrom-Json
     if ($parsed.status -ne 0) {
         throw ($parsed.message)

--- a/psfdx-packages/psfdx-packages.Tests.ps1
+++ b/psfdx-packages/psfdx-packages.Tests.ps1
@@ -5,13 +5,13 @@ Import-Module $moduleManifest -Force | Out-Null
 Describe 'New-SalesforcePackage' {
     InModuleScope 'psfdx-packages' {
         BeforeEach {
-            Mock Invoke-Sf { '{"status":0,"result":{"Id":"0Ho000000000001"}}' }
+            Mock Invoke-Salesforce { '{"status":0,"result":{"Id":"0Ho000000000001"}}' }
             Mock Show-SfResult { param($Result) return @{ Id = '0Ho000000000001' } }
         }
         It 'uses target-dev-hub and returns package id' {
             $id = New-SalesforcePackage -Name 'MyPkg' -DevHubUsername 'devhub' -PackageType Managed
             $id | Should -Be '0Ho000000000001'
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Command -like 'sf package create * --target-dev-hub devhub*' }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Command -like 'sf package create * --target-dev-hub devhub*' }
         }
     }
 }
@@ -19,23 +19,23 @@ Describe 'New-SalesforcePackage' {
 Describe 'New-SalesforcePackageVersion' {
     InModuleScope 'psfdx-packages' {
         BeforeEach {
-            Mock Invoke-Sf { '{"status":0,"result":{"id":"04t000000000001"}}' }
+            Mock Invoke-Salesforce { '{"status":0,"result":{"id":"04t000000000001"}}' }
             Mock Show-SfResult { @{ id = '04t000000000001' } }
         }
         It 'includes target-dev-hub and json' {
             $out = New-SalesforcePackageVersion -PackageId '0Ho000000000001' -DevHubUsername 'devhub' -WaitMinutes 10
             $out.id | Should -Be '04t000000000001'
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -like 'sf package version create *') -and ($Command -like '* --target-dev-hub devhub*') -and ($Command -like '* --json') }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -like 'sf package version create *') -and ($Command -like '* --target-dev-hub devhub*') -and ($Command -like '* --json') }
         }
     }
 }
 
 Describe 'Install-SalesforcePackageVersion' {
     InModuleScope 'psfdx-packages' {
-        BeforeEach { Mock Invoke-Sf {} }
+        BeforeEach { Mock Invoke-Salesforce {} }
         It 'targets org and sets waits' {
             Install-SalesforcePackageVersion -PackageVersionId '04t...' -TargetOrg 'me' -WaitMinutes 5 -NoPrompt | Out-Null
-            Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { ($Command -like 'sf package install *') -and ($Command -like '* --target-org me*') -and ($Command -like '* --wait 5*') -and ($Command -like '* --publish-wait 5*') -and ($Command -like '* --no-prompt*') }
+            Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -like 'sf package install *') -and ($Command -like '* --target-org me*') -and ($Command -like '* --wait 5*') -and ($Command -like '* --publish-wait 5*') -and ($Command -like '* --no-prompt*') }
         }
     }
 }

--- a/psfdx-packages/psfdx-packages.psm1
+++ b/psfdx-packages/psfdx-packages.psm1
@@ -1,4 +1,4 @@
-function Invoke-Sf {
+function Invoke-Salesforce {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Command)
     Write-Verbose $Command
@@ -27,7 +27,7 @@ function Get-SalesforcePackages {
         $command += " --verbose"
     }
     $command += " --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -67,7 +67,7 @@ function New-SalesforcePackage {
     }
     $command += " --target-dev-hub $DevHubUsername"
     $command += " --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     $resultSfdx = Show-SfResult -Result $result
     return $resultSfdx.Id
 }
@@ -84,7 +84,7 @@ function Remove-SalesforcePackage {
         $command += " --no-prompt"
     }
     $command += " --target-dev-hub $DevHubUsername"
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }
 function New-SalesforcePackageVersion {
     [CmdletBinding()]
@@ -145,7 +145,7 @@ function New-SalesforcePackageVersion {
     }
 
     $command += " --json"
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -181,7 +181,7 @@ function Get-SalesforcePackageVersions {
     }
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -201,7 +201,7 @@ function Promote-SalesforcePackageVersion {
     }
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -221,7 +221,7 @@ function Remove-SalesforcePackageVersion {
     }
     $command += " --json"
 
-    $result = Invoke-Sf -Command $command
+    $result = Invoke-Salesforce -Command $command
     return Show-SfResult -Result $result
 }
 
@@ -244,5 +244,5 @@ function Install-SalesforcePackageVersion {
         $command += " --wait $WaitMinutes"
         $command += " --publish-wait $WaitMinutes"
     }
-    Invoke-Sf -Command $command
+    Invoke-Salesforce -Command $command
 }

--- a/psfdx/psfdx.Tests.ps1
+++ b/psfdx/psfdx.Tests.ps1
@@ -22,23 +22,23 @@ Describe 'psfdx module' {
     InModuleScope $module.Name {
         Context 'Alias commands' {
             It 'sets alias using equals syntax' {
-                Mock Invoke-Sf {} -ModuleName $module.Name
+                Mock Invoke-Salesforce {} -ModuleName $module.Name
                 Add-SalesforceAlias -Alias 'my' -TargetOrg 'user@example.com'
-                Assert-MockCalled Invoke-Sf -Times 1 -ModuleName $module.Name -ParameterFilter { $Arguments -eq 'alias set my=user@example.com' }
+                Assert-MockCalled Invoke-Salesforce -Times 1 -ModuleName $module.Name -ParameterFilter { $Arguments -eq 'alias set my=user@example.com' }
             }
 
             It 'unsets alias without stray leading space' {
-                Mock Invoke-Sf {} -ModuleName $module.Name
+                Mock Invoke-Salesforce {} -ModuleName $module.Name
                 Remove-SalesforceAlias -Alias 'my'
-                Assert-MockCalled Invoke-Sf -Times 1 -ModuleName $module.Name -ParameterFilter { $Arguments -eq 'alias unset my' }
+                Assert-MockCalled Invoke-Salesforce -Times 1 -ModuleName $module.Name -ParameterFilter { $Arguments -eq 'alias unset my' }
             }
         }
 
         Context 'Connect-Salesforce' {
             It 'includes --set-default-dev-hub when requested' {
-                Mock Invoke-Sf { '{"status":0,"result":{}}' } -ModuleName $module.Name
+                Mock Invoke-Salesforce { '{"status":0,"result":{}}' } -ModuleName $module.Name
                 Connect-Salesforce -SetDefaultDevHub
-                Assert-MockCalled Invoke-Sf -Times 1 -ModuleName $module.Name -ParameterFilter { $Arguments -like '* --set-default-dev-hub*' }
+                Assert-MockCalled Invoke-Salesforce -Times 1 -ModuleName $module.Name -ParameterFilter { $Arguments -like '* --set-default-dev-hub*' }
             }
         }
 
@@ -48,15 +48,15 @@ Describe 'psfdx module' {
             }
 
             It 'uses login URL for production' {
-                Mock Invoke-Sf { '{"status":0,"result":{}}' }
+                Mock Invoke-Salesforce { '{"status":0,"result":{}}' }
                 Connect-SalesforceJwt -ConsumerKey 'ck' -TargetOrg 'u' -JwtKeyfile 'key.pem'
-                Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Arguments -like '* --instance-url https://login.salesforce.com*' }
+                Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Arguments -like '* --instance-url https://login.salesforce.com*' }
             }
 
             It 'uses test URL for sandbox' {
-                Mock Invoke-Sf { '{"status":0,"result":{}}' }
+                Mock Invoke-Salesforce { '{"status":0,"result":{}}' }
                 Connect-SalesforceJwt -ConsumerKey 'ck' -TargetOrg 'u' -JwtKeyfile 'key.pem' -Sandbox
-                Assert-MockCalled Invoke-Sf -Times 1 -ParameterFilter { $Arguments -like '* --instance-url https://test.salesforce.com*' }
+                Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { $Arguments -like '* --instance-url https://test.salesforce.com*' }
             }
         }
 
@@ -65,7 +65,7 @@ Describe 'psfdx module' {
                 $json = @'
 {"status":0,"result":{"records":[{"Id":"001xx0000000001"}]}}
 '@
-                Mock Invoke-Sf { $json } -ModuleName $module.Name
+                Mock Invoke-Salesforce { $json } -ModuleName $module.Name
                 $rows = Select-SalesforceRecords -Query 'SELECT Id FROM Account LIMIT 1' -TargetOrg 'me'
                 $rows.Count | Should -Be 1
                 $rows[0].Id | Should -Be '001xx0000000001'
@@ -77,7 +77,7 @@ Describe 'psfdx module' {
                 $json = @'
 {"status":0,"result":{"id":"001xx0000000001"}}
 '@
-                Mock Invoke-Sf { $json } -ModuleName $module.Name
+                Mock Invoke-Salesforce { $json } -ModuleName $module.Name
                 $res = New-SalesforceRecord -Type Account -FieldUpdates 'Name=Acme' -TargetOrg me
                 $res.id | Should -Be '001xx0000000001'
             }
@@ -86,7 +86,7 @@ Describe 'psfdx module' {
                 $json = @'
 {"status":0,"result":{"success":true}}
 '@
-                Mock Invoke-Sf { $json } -ModuleName $module.Name
+                Mock Invoke-Salesforce { $json } -ModuleName $module.Name
                 $res = Set-SalesforceRecord -Id '001xx0000000001' -Type Account -FieldUpdates 'Name=Updated' -TargetOrg me
                 $res.success | Should -BeTrue
             }

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -1,4 +1,4 @@
-function Invoke-Sf {
+function Invoke-Salesforce {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Arguments)
     Write-Verbose $Arguments
@@ -53,7 +53,7 @@ function Connect-Salesforce {
     if ($OAuthClientId) { $arguments += " --client-id $OAuthClientId" }
     if ($Browser) { $arguments += " --browser $Browser" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     Show-SfResult -Result $result
 }
 
@@ -73,7 +73,7 @@ function Disconnect-Salesforce {
     }
     if ($NoPrompt) { $arguments += " --no-prompt" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     Show-SfResult -Result $result
 }
 
@@ -97,7 +97,7 @@ function Connect-SalesforceJwt {
     if ($SetDefaultUsername) { $arguments += " --set-default" }
     $arguments += " --json"
 
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     return Show-SfResult -Result $result
 }
 
@@ -112,7 +112,7 @@ function Open-Salesforce {
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     if ($Browser) { $arguments += " --browser $Browser" }
     if ($UrlOnly) { $arguments += " --url-only" }
-    Invoke-Sf -Arguments $arguments
+    Invoke-Salesforce -Arguments $arguments
 }
 
 function Get-SalesforceConnections {
@@ -123,7 +123,7 @@ function Get-SalesforceConnections {
     $arguments = "org list"
     if ($ShowVerboseDetails) { $arguments += " --verbose" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
 
     $result = $result | ConvertFrom-Json
     $result = $result.result.nonScratchOrgs # Exclude Scratch Orgs
@@ -136,12 +136,12 @@ function Repair-SalesforceConnections {
     Param([Parameter(Mandatory = $false)][switch] $NoPrompt)
     $arguments = "org list --clean"
     if ($NoPrompt) { $arguments += " --no-prompt" }
-    Invoke-Sf -Arguments $arguments
+    Invoke-Salesforce -Arguments $arguments
 }
 
 function Get-SalesforceAlias {
     [CmdletBinding()]
-    $result = Invoke-Sf -Arguments "alias list --json"
+    $result = Invoke-Salesforce -Arguments "alias list --json"
     return Show-SfResult -Result $result
 }
 
@@ -151,13 +151,13 @@ function Add-SalesforceAlias {
         [Parameter(Mandatory = $true)][string] $Alias,
         [Parameter(Mandatory = $true)][string] $TargetOrg
     )
-    Invoke-Sf -Arguments "alias set $Alias=$TargetOrg"
+    Invoke-Salesforce -Arguments "alias set $Alias=$TargetOrg"
 }
 
 function Remove-SalesforceAlias {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Alias)
-    Invoke-Sf -Arguments "alias unset $Alias"
+    Invoke-Salesforce -Arguments "alias unset $Alias"
 }
 
 function Get-SalesforceLimits {
@@ -166,7 +166,7 @@ function Get-SalesforceLimits {
     $arguments = "limits api display"
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     return Show-SfResult -Result $result
 }
 
@@ -206,7 +206,7 @@ function Select-SalesforceRecords {
     $arguments += " --result-format $ResultFormat"
     Write-Verbose ("Query: " + $Query)
     Write-Verbose $arguments
-    $result = Invoke-Sf -Arguments $arguments | ConvertFrom-Json
+    $result = Invoke-Salesforce -Arguments $arguments | ConvertFrom-Json
     if ($result.status -ne 0) {
         $result
         throw $result.message
@@ -244,7 +244,7 @@ function New-SalesforceRecord {
     if ($UseToolingApi) { $arguments += " --use-tooling-api" }
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     return Show-SfResult -Result $result
 }
 
@@ -281,7 +281,7 @@ function Set-SalesforceRecord {
     if ($UseToolingApi) { $arguments += " --use-tooling-api" }
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     return Show-SfResult -Result $result
 }
 
@@ -307,7 +307,7 @@ function Invoke-SalesforceApexFile {
     $arguments = "apex run --file $ApexFile"
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
-    $result = Invoke-Sf -Arguments $arguments
+    $result = Invoke-Salesforce -Arguments $arguments
     return Show-SfResult -Result $result
 }
 
@@ -352,7 +352,7 @@ function Install-SalesforcePlugin {
         [Parameter(Mandatory = $true)][string] $Name
     )
     $arguments = "plugins install $Name"
-    Invoke-Sf -Arguments $arguments
+    Invoke-Salesforce -Arguments $arguments
 }
 
 function Get-SalesforcePlugins {
@@ -362,11 +362,11 @@ function Get-SalesforcePlugins {
     )
     $arguments = "plugins"
     if ($IncludeCore) { $arguments += " --core" }
-    Invoke-Sf -Arguments $arguments
+    Invoke-Salesforce -Arguments $arguments
 }
 
 function Update-SalesforcePlugins {
     [CmdletBinding()]
     Param()
-    Invoke-Sf -Arguments "plugins update"
+    Invoke-Salesforce -Arguments "plugins update"
 }


### PR DESCRIPTION
This PR renames the internal helper function from `Invoke-Sf` to `Invoke-Salesforce` across all modules and updates the tests accordingly.

Summary:
- Rename helper in modules: `psfdx`, `psfdx-development`, `psfdx-logs`, `psfdx-metadata`, `psfdx-packages`.
- Update all call sites to the new function name.
- Update Pester tests to mock/assert the new helper.
- No manifest exports changed; helper remains private.

Validation:
- Ran Pester locally: Passed 30, Failed 0, Skipped 1.

This keeps naming consistent and more descriptive for Salesforce command execution.