### PR TITLE
Rename Show-SfResult to Show-SalesforceResult

### DIFF
--- a/psfdx-development/psfdx-development.psm1
+++ b/psfdx-development/psfdx-development.psm1
@@ -5,7 +5,7 @@ function Invoke-Salesforce {
     return Invoke-Expression -Command $Command
 }
 
-function Show-SfResult {
+function Show-SalesforceResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
     $result = $Result | ConvertFrom-Json
@@ -49,7 +49,7 @@ function Get-SalesforceConfig {
     Param()
     $command = "sf config list --json"
     $result = Invoke-Salesforce -Command $command
-    Show-SfResult -Result $result
+    Show-SalesforceResult -Result $result
 }
 
 function Get-SalesforceScratchOrgs {
@@ -98,7 +98,7 @@ function New-SalesforceScratchOrg {
     $command += " --json"
 
     $result = Invoke-Salesforce -Command $command
-    Show-SfResult -Result $result
+    Show-SalesforceResult -Result $result
 
     $scratchOrgUsername = $result.username
     if ($Set) {
@@ -160,7 +160,7 @@ function New-SalesforceProject {
     $command += " --json"
 
     $result = Invoke-Salesforce -Command $command
-    $result = Show-SfResult -Result $result
+    $result = Show-SalesforceResult -Result $result
 
     if (($null -ne $DefaultUserName) -and ($DefaultUserName -ne '')) {
         $projectFolder = Join-Path -Path $result.outputDir -ChildPath $Name
@@ -443,7 +443,7 @@ function New-SalesforceJestTest {
     $filePath = "force-app/main/default/lwc/$LwcName/$LwcName.js"
     $command = "sf force lightning lwc test create --filepath $filePath --json"
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Test-SalesforceJest {

--- a/psfdx-logs/psfdx-logs.Tests.ps1
+++ b/psfdx-logs/psfdx-logs.Tests.ps1
@@ -28,13 +28,13 @@ Describe 'Get-SalesforceLogs' {
     InModuleScope 'psfdx-logs' {
         BeforeEach {
             Mock Invoke-Salesforce { '{"status":0,"result":[{"Id":"1"}]}' }
-            Mock Show-SfResult { return @(@{ Id = '1' }) }
+            Mock Show-SalesforceResult { return @(@{ Id = '1' }) }
         }
         It 'lists logs with json' {
             $out = Get-SalesforceLogs
             $out | Should -Not -BeNullOrEmpty
             Assert-MockCalled Invoke-Salesforce -Times 1 -ParameterFilter { ($Command -join ' ') -eq 'sf apex log list --json' }
-            Assert-MockCalled Show-SfResult -Times 1
+            Assert-MockCalled Show-SalesforceResult -Times 1
         }
         It 'adds username when provided' {
             Get-SalesforceLogs -TargetOrg 'user@example' | Out-Null

--- a/psfdx-logs/psfdx-logs.psm1
+++ b/psfdx-logs/psfdx-logs.psm1
@@ -9,7 +9,7 @@ function Invoke-Salesforce {
     return & $exe @args
 }
 
-function Show-SfResult {
+function Show-SalesforceResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
     $result = $Result | ConvertFrom-Json
@@ -42,7 +42,7 @@ function Get-SalesforceLogs {
     if ($TargetOrg) { $command += @('--target-org', $TargetOrg) }
     $command += @('--json')
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Get-SalesforceLog {
@@ -61,7 +61,7 @@ function Get-SalesforceLog {
     if ($TargetOrg) { $command += @('--target-org', $TargetOrg) }
     $command += @('--json')
     $raw = Invoke-Salesforce -Command $command
-    $parsed = Show-SfResult -Result $raw
+    $parsed = Show-SalesforceResult -Result $raw
     return $parsed.log
 }
 

--- a/psfdx-metadata/psfdx-metadata.psm1
+++ b/psfdx-metadata/psfdx-metadata.psm1
@@ -5,7 +5,7 @@ function Invoke-Salesforce {
     return Invoke-Expression -Command $Command
 }
 
-function Show-SfResult {
+function Show-SalesforceResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
     $result = $Result | ConvertFrom-Json
@@ -452,7 +452,7 @@ function Deploy-SalesforceComponent {
     $command += " --json"
 
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Describe-SalesforceObjects {
@@ -466,7 +466,7 @@ function Describe-SalesforceObjects {
     $command += " --target-org $TargetOrg"
     $command += " --json"
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Describe-SalesforceObject {
@@ -486,7 +486,7 @@ function Describe-SalesforceObject {
     }
     $command += " --json"
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Describe-SalesforceFields {

--- a/psfdx-packages/psfdx-packages.Tests.ps1
+++ b/psfdx-packages/psfdx-packages.Tests.ps1
@@ -6,7 +6,7 @@ Describe 'New-SalesforcePackage' {
     InModuleScope 'psfdx-packages' {
         BeforeEach {
             Mock Invoke-Salesforce { '{"status":0,"result":{"Id":"0Ho000000000001"}}' }
-            Mock Show-SfResult { param($Result) return @{ Id = '0Ho000000000001' } }
+            Mock Show-SalesforceResult { param($Result) return @{ Id = '0Ho000000000001' } }
         }
         It 'uses target-dev-hub and returns package id' {
             $id = New-SalesforcePackage -Name 'MyPkg' -DevHubUsername 'devhub' -PackageType Managed
@@ -20,7 +20,7 @@ Describe 'New-SalesforcePackageVersion' {
     InModuleScope 'psfdx-packages' {
         BeforeEach {
             Mock Invoke-Salesforce { '{"status":0,"result":{"id":"04t000000000001"}}' }
-            Mock Show-SfResult { @{ id = '04t000000000001' } }
+            Mock Show-SalesforceResult { @{ id = '04t000000000001' } }
         }
         It 'includes target-dev-hub and json' {
             $out = New-SalesforcePackageVersion -PackageId '0Ho000000000001' -DevHubUsername 'devhub' -WaitMinutes 10

--- a/psfdx-packages/psfdx-packages.psm1
+++ b/psfdx-packages/psfdx-packages.psm1
@@ -5,7 +5,7 @@ function Invoke-Salesforce {
     return Invoke-Expression -Command $Command
 }
 
-function Show-SfResult {
+function Show-SalesforceResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
     $result = $Result | ConvertFrom-Json
@@ -28,7 +28,7 @@ function Get-SalesforcePackages {
     }
     $command += " --json"
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Get-SalesforcePackage {
@@ -68,7 +68,7 @@ function New-SalesforcePackage {
     $command += " --target-dev-hub $DevHubUsername"
     $command += " --json"
     $result = Invoke-Salesforce -Command $command
-    $resultSfdx = Show-SfResult -Result $result
+    $resultSfdx = Show-SalesforceResult -Result $result
     return $resultSfdx.Id
 }
 
@@ -146,7 +146,7 @@ function New-SalesforcePackageVersion {
 
     $command += " --json"
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Get-SalesforcePackageVersions {
@@ -182,7 +182,7 @@ function Get-SalesforcePackageVersions {
     $command += " --json"
 
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Promote-SalesforcePackageVersion {
@@ -202,7 +202,7 @@ function Promote-SalesforcePackageVersion {
     $command += " --json"
 
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Remove-SalesforcePackageVersion {
@@ -222,7 +222,7 @@ function Remove-SalesforcePackageVersion {
     $command += " --json"
 
     $result = Invoke-Salesforce -Command $command
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Install-SalesforcePackageVersion {

--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -18,7 +18,7 @@ function Invoke-Salesforce {
     return $stdout
 }
 
-function Show-SfResult {
+function Show-SalesforceResult {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][psobject] $Result)
     $result = $Result | ConvertFrom-Json
@@ -54,7 +54,7 @@ function Connect-Salesforce {
     if ($Browser) { $arguments += " --browser $Browser" }
     $arguments += " --json"
     $result = Invoke-Salesforce -Arguments $arguments
-    Show-SfResult -Result $result
+    Show-SalesforceResult -Result $result
 }
 
 function Disconnect-Salesforce {
@@ -74,7 +74,7 @@ function Disconnect-Salesforce {
     if ($NoPrompt) { $arguments += " --no-prompt" }
     $arguments += " --json"
     $result = Invoke-Salesforce -Arguments $arguments
-    Show-SfResult -Result $result
+    Show-SalesforceResult -Result $result
 }
 
 function Connect-SalesforceJwt {
@@ -98,7 +98,7 @@ function Connect-SalesforceJwt {
     $arguments += " --json"
 
     $result = Invoke-Salesforce -Arguments $arguments
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Open-Salesforce {
@@ -142,7 +142,7 @@ function Repair-SalesforceConnections {
 function Get-SalesforceAlias {
     [CmdletBinding()]
     $result = Invoke-Salesforce -Arguments "alias list --json"
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Add-SalesforceAlias {
@@ -167,7 +167,7 @@ function Get-SalesforceLimits {
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
     $result = Invoke-Salesforce -Arguments $arguments
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Get-SalesforceDataStorage {
@@ -245,7 +245,7 @@ function New-SalesforceRecord {
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
     $result = Invoke-Salesforce -Arguments $arguments
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 <#
@@ -282,7 +282,7 @@ function Set-SalesforceRecord {
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
     $result = Invoke-Salesforce -Arguments $arguments
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Get-SalesforceRecordType {
@@ -308,7 +308,7 @@ function Invoke-SalesforceApexFile {
     if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
     $arguments += " --json"
     $result = Invoke-Salesforce -Arguments $arguments
-    return Show-SfResult -Result $result
+    return Show-SalesforceResult -Result $result
 }
 
 function Connect-SalesforceApi {


### PR DESCRIPTION
This PR renames the internal result-parsing helper from `Show-SfResult` to `Show-SalesforceResult` across all modules and updates tests.

Summary:
- Rename helper in modules: `psfdx`, `psfdx-development`, `psfdx-logs`, `psfdx-metadata`, `psfdx-packages`.
- Update all call sites to the new function name.
- Update Pester tests to mock/assert the new helper name.
- No manifest exports changed; helper remains private.

Validation:
- Ran Pester locally: Passed 30, Failed 0, Skipped 1.