### PR TITLE
Windows: make Invoke-Salesforce start sf reliably

### DIFF
--- a/psfdx/psfdx.psm1
+++ b/psfdx/psfdx.psm1
@@ -1,14 +1,50 @@
 function Invoke-Salesforce {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $Arguments)
-    Write-Verbose "sf $Arguments"
+
+    # Determine Windows reliably across PS 5.1 and 7+
+    $isWin = ($PSVersionTable.PSEdition -eq 'Desktop') -or ($IsWindows -eq $true)
+
+    # Resolve the full path to 'sf' and prefer native exe where available
+    $sfPath = $null
+    $sfExePath = $null
+    try { $sfPath = (Get-Command 'sf' -ErrorAction Stop).Path } catch {}
+    if ($isWin) {
+        try { $sfExePath = (Get-Command 'sf.exe' -ErrorAction Stop).Path } catch {}
+    }
+
     $psi = New-Object System.Diagnostics.ProcessStartInfo
-    $psi.FileName = "sf"
-    $psi.Arguments = $Arguments
+    if ($isWin -and $sfExePath) {
+        # Use native sf.exe directly (no cmd.exe), supports redirection
+        $psi.FileName  = $sfExePath
+        $psi.Arguments = $Arguments
+        Write-Verbose ('sf ' + $Arguments)
+    }
+    elseif ($isWin) {
+        # Fallback: use cmd.exe to execute sf.cmd shim
+        $sfDisplay = if ($sfPath) { '"' + $sfPath + '"' } else { 'sf' }
+        $psi.FileName  = 'cmd.exe'
+        $psi.Arguments = '/c ' + $sfDisplay + ' ' + $Arguments
+        Write-Verbose ('sf ' + $Arguments)
+    }
+    else {
+        $psi.FileName  = if ($sfPath) { $sfPath } else { 'sf' }
+        $psi.Arguments = $Arguments
+        Write-Verbose ('sf ' + $Arguments)
+    }
+
     $psi.RedirectStandardOutput = $true
-    $psi.RedirectStandardError = $true
-    $psi.UseShellExecute = $false
-    $process = [System.Diagnostics.Process]::Start($psi)
+    $psi.RedirectStandardError  = $true
+    $psi.UseShellExecute        = $false
+
+    try {
+        $process = [System.Diagnostics.Process]::Start($psi)
+    }
+    catch {
+        $hint = if ($sfCmd) { " (resolved path: $sfCmd)" } else { '' }
+        throw "Failed to start Salesforce CLI 'sf'$hint. Ensure it is installed and on PATH. Details: $($_.Exception.Message)"
+    }
+
     $stdout = $process.StandardOutput.ReadToEnd()
     $stderr = $process.StandardError.ReadToEnd()
     $process.WaitForExit()


### PR DESCRIPTION
This PR fixes Salesforce CLI invocation on Windows:

- Prefer native `sf.exe` when available (no cmd.exe required).
- Fallback to `cmd.exe /c sf` only if the shim (`sf.cmd`) is the only option.
- Improve verbose output to show `sf <args>`.
- Add clearer error message when the process fails to start.

Why:
- Running .cmd with UseShellExecute=false fails when started directly via ProcessStartInfo; using `sf.exe` avoids this and keeps output redirection.

Validation:
- Pester: Passed 30, Failed 0, Skipped 1.
- Linux remains unaffected (invokes resolved `sf` path directly).