### PR TITLE
docs: document Invoke-Salesforce usage (-Arguments vs -Command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,11 @@ Get-Command -Module psfdx
 * `Promote-SalesforcePackageVersion` - Promote a package version
 * `Install-SalesforcePackageVersion` - Install a package version
 
+## Shared Helpers
+- `psfdx-shared/Invoke-Salesforce.ps1`:
+  - Use `-Arguments` when invoking the Salesforce CLI (`sf ...`). Pass the part after `sf`; the helper prepends `sf` automatically.
+  - Use `-Command` for non-`sf` commands (e.g., `npm`, `yarn`) or when supplying a string array for precise argument handling.
+- `psfdx-shared/Show-SalesforceResult.ps1`: Parses JSON output from `sf` commands and throws on non-zero `status`.
+
 ## Breaking Changes
 - All cmdlets now use `-TargetOrg` instead of `-Username` to specify the org (username or alias). Update scripts accordingly.


### PR DESCRIPTION
Adds a README section describing when to use the shared helpers:\n\n- Use -Arguments for sf CLI commands (helper prepends 'sf')\n- Use -Command for non-sf commands (npm/yarn) or array invocations\n- Notes the shared Show-SalesforceResult behavior\n\nThis codifies the pattern used across modules: psfdx/psfdx-metadata/psfdx-packages use -Arguments; psfdx-development and psfdx-logs use -Command.