### PR TITLE
docs: add changelog for -Command migration and shared helper centralization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## Unreleased
+
+- Replace `Invoke-Salesforce -Arguments` with `-Command "sf …"` across modules to allow non-`sf` commands where needed.
+- Centralize `Invoke-Salesforce` and `Show-SalesforceResult` into `psfdx-shared/` and dot-source across all modules.
+- Rename folder `shared/` to `psfdx-shared/`.
+- psfdx-development: Rename `$DevhubUsername` to `$TargetDevHub` and update callers.
+- Documentation: Add guidance on using `-Command` vs `-Arguments` for shared helpers.
+


### PR DESCRIPTION
This PR adds a CHANGELOG describing recent refactors and documentation updates:\n\n- Replaced Invoke-Salesforce -Arguments with -Command 'sf …' where appropriate\n- Centralized Invoke-Salesforce and Show-SalesforceResult into psfdx-shared/\n- Renamed shared/ to psfdx-shared/\n- Renamed  to  in psfdx-development\n- Added README guidance on -Command vs -Arguments\n\nThis provides a clear history for consumers of the modules.