### PR TITLE
chore: bump all module versions to 0.5 and align manifests

### DIFF
--- a/psfdx-development/psfdx-development.psd1
+++ b/psfdx-development/psfdx-development.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'psfdx-development.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.1.1'
+    ModuleVersion     = '0.5'
 
     # Supported PowerShell editions: Desktop = Windows PowerShell, Core = PowerShell 7+
     CompatiblePSEditions = @('Desktop','Core')

--- a/psfdx-logs/psfdx-logs.psd1
+++ b/psfdx-logs/psfdx-logs.psd1
@@ -3,7 +3,7 @@
     RootModule        = 'psfdx-logs.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '0.1.0'
+    ModuleVersion     = '0.5'
 
     # Supported PowerShell editions: Desktop = Windows PowerShell, Core = PowerShell 7+
     CompatiblePSEditions = @('Desktop','Core')

--- a/psfdx-metadata/psfdx-metadata.psd1
+++ b/psfdx-metadata/psfdx-metadata.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule            = 'psfdx-metadata.psm1'
-    ModuleVersion         = '0.1.0'
+    ModuleVersion         = '0.5'
     CompatiblePSEditions  = @('Desktop','Core')
     GUID                  = 'e0c7c8c3-0f5f-4662-a9e1-2c3c5a1c7f20'
     Author                = 'Tony Ward'

--- a/psfdx-packages/psfdx-packages.psd1
+++ b/psfdx-packages/psfdx-packages.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule            = 'psfdx-packages.psm1'
-    ModuleVersion         = '0.1.0'
+    ModuleVersion         = '0.5'
     CompatiblePSEditions  = @('Desktop','Core')
     GUID                  = '0d7f0c6c-8f1b-4eb6-9f6a-55f7a7c3f2b1'
     Author                = 'Tony Ward'

--- a/psfdx/psfdx.psd1
+++ b/psfdx/psfdx.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule = 'psfdx.psm1'
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.5'
     GUID = '2785d2bf-775f-4f2b-9d00-ee98f0163cf0'
     Author = 'Tony Ward'
     Description = 'PowerShell module that wraps Salesforce SFDX command line interface'


### PR DESCRIPTION
Bumps ModuleVersion to 0.5 across all modules and aligns manifests for consistency.\n\nModules updated:\n- psfdx\n- psfdx-development\n- psfdx-logs\n- psfdx-metadata\n- psfdx-packages\n\nNo functional changes; versioning alignment only.