### PR TITLE
Refactor: build single $command for all Salesforce CLI invocations

### DIFF
--- a/psfdx-development/psfdx-development.psm1
+++ b/psfdx-development/psfdx-development.psm1
@@ -129,20 +129,10 @@ function New-SalesforceProject {
         [Parameter(Mandatory = $false)][switch] $GenerateManifest
     )
     $command = "sf force project create --name $Name"
-
-    if ($OutputDirectory) {
-        $command += " --output-dir $OutputDirectory"
-    }
-    if ($DefaultPackageDirectory) {
-        $command += " --default-package-dir $DefaultPackageDirectory"
-    }
-    if ($Namespace) {
-        $command += " --namespace $Namespace"
-    }
-    if ($GenerateManifest) {
-        $command += " --manifest"
-    }
-
+    if ($OutputDirectory) { $command += " --output-dir $OutputDirectory" }
+    if ($DefaultPackageDirectory) { $command += " --default-package-dir $DefaultPackageDirectory" }
+    if ($Namespace) { $command += " --namespace $Namespace" }
+    if ($GenerateManifest) { $command += " --manifest" }
     $command += " --template $Template"
     $command += " --json"
 
@@ -179,8 +169,7 @@ function Set-SalesforceProject {
 
     if (($null -eq $ProjectFolder) -or ($ProjectFolder -eq '')) {
         $sfdxFolder = (Get-Location).Path
-    }
-    else {
+    } else {
         $sfdxFolder = $ProjectFolder
     }
 

--- a/psfdx-metadata/psfdx-metadata.psm1
+++ b/psfdx-metadata/psfdx-metadata.psm1
@@ -10,15 +10,15 @@ function Retrieve-SalesforceOrg {
         [Parameter(Mandatory = $false)][switch] $IncludePackages
     )
 
-    $arguments = "force source manifest create --from-org $TargetOrg"
-    $arguments += " --name=allMetadata"
-    $arguments += " --output-dir ."
-    if ($IncludePackages) { $arguments += " --include-packages=unlocked" }
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf force source manifest create --from-org $TargetOrg"
+    $command += " --name=allMetadata"
+    $command += " --output-dir ."
+    if ($IncludePackages) { $command += " --include-packages=unlocked" }
+    Invoke-Salesforce -Command $command
 
-    $arguments = "project retrieve start --target-org $TargetOrg"
-    $arguments += " --manifest allMetadata.xml"
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf project retrieve start --target-org $TargetOrg"
+    $command += " --manifest allMetadata.xml"
+    Invoke-Salesforce -Command $command
 }
 
 function Retrieve-SalesforceComponent {
@@ -212,10 +212,10 @@ function Retrieve-SalesforceComponent {
         [Parameter(Mandatory = $false)][string] $TargetOrg
     )
 
-    $arguments = "project retrieve start --metadata $Type"
-    if ($Name) { $arguments += ":$Name" }
-    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf project retrieve start --metadata $Type"
+    if ($Name) { $command += ":$Name" }
+    if ($TargetOrg) { $command += " --target-org $TargetOrg" }
+    Invoke-Salesforce -Command $command
 }
 
 function Retrieve-SalesforceField {
@@ -224,9 +224,9 @@ function Retrieve-SalesforceField {
         [Parameter(Mandatory = $true)][string] $ObjectName,
         [Parameter(Mandatory = $true)][string] $FieldName,
         [Parameter(Mandatory = $false)][string] $TargetOrg)
-    $arguments = "project retrieve start --metadata CustomField:$ObjectName.$FieldName"
-    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf project retrieve start --metadata CustomField:$ObjectName.$FieldName"
+    if ($TargetOrg) { $command += " --target-org $TargetOrg" }
+    Invoke-Salesforce -Command $command
 }
 
 function Retrieve-SalesforceValidationRule {
@@ -235,9 +235,9 @@ function Retrieve-SalesforceValidationRule {
         [Parameter(Mandatory = $true)][string] $ObjectName,
         [Parameter(Mandatory = $true)][string] $RuleName,
         [Parameter(Mandatory = $false)][string] $TargetOrg)
-    $arguments = "project retrieve start --metadata ValidationRule:$ObjectName.$RuleName"
-    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf project retrieve start --metadata ValidationRule:$ObjectName.$RuleName"
+    if ($TargetOrg) { $command += " --target-org $TargetOrg" }
+    Invoke-Salesforce -Command $command
 }
 
 function Deploy-SalesforceComponent {
@@ -430,15 +430,12 @@ function Deploy-SalesforceComponent {
         [Parameter(Mandatory = $false)][string] $Name,
         [Parameter(Mandatory = $true)][string] $TargetOrg
     )
-    $arguments = "project deploy start"
-    $arguments += " --metadata $Type"
-    if ($Name) {
-        $arguments += ":$Name"
-    }
-    $arguments += " --target-org $TargetOrg"
-    $arguments += " --json"
-
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf project deploy start"
+    $command += " --metadata $Type"
+    if ($Name) { $command += ":$Name" }
+    $command += " --target-org $TargetOrg"
+    $command += " --json"
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -448,11 +445,11 @@ function Describe-SalesforceObjects {
         [Parameter(Mandatory = $true)][string] $TargetOrg,
         [Parameter(Mandatory = $false)][string][ValidateSet('all', 'custom', 'standard')] $ObjectTypeCategory = 'all'
     )
-    $arguments = "sobject list"
-    $arguments += " --category $ObjectTypeCategory"
-    $arguments += " --target-org $TargetOrg"
-    $arguments += " --json"
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf sobject list"
+    $command += " --category $ObjectTypeCategory"
+    $command += " --target-org $TargetOrg"
+    $command += " --json"
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -463,16 +460,12 @@ function Describe-SalesforceObject {
         [Parameter(Mandatory = $false)][string] $TargetOrg,
         [Parameter(Mandatory = $false)][switch] $UseToolingApi
     )
-    $arguments = "sobject describe"
-    if ($TargetOrg) {
-        $arguments += " --target-org $TargetOrg"
-    }
-    $arguments += " --sobject $Name"
-    if ($UseToolingApi) {
-        $arguments += " --use-tooling-api"
-    }
-    $arguments += " --json"
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf sobject describe"
+    if ($TargetOrg) { $command += " --target-org $TargetOrg" }
+    $command += " --sobject $Name"
+    if ($UseToolingApi) { $command += " --use-tooling-api" }
+    $command += " --json"
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -492,11 +485,11 @@ function Describe-SalesforceFields {
 function Get-SalesforceMetaTypes {
     [CmdletBinding()]
     Param([Parameter(Mandatory = $true)][string] $TargetOrg)
-    $arguments = "org list metadata-types"
-    $arguments += " --target-org $TargetOrg"
-    $arguments += " --json"
+    $command = "sf org list metadata-types"
+    $command += " --target-org $TargetOrg"
+    $command += " --json"
 
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $result = Invoke-Salesforce -Command $command
     $result = $result | ConvertFrom-Json
     $result = $result.result.metadataObjects
     $result = $result | Select-Object xmlName
@@ -510,7 +503,8 @@ function Get-SalesforceApexClass {
         [Parameter(Mandatory = $true)][string] $TargetOrg
     )
     $query = "SELECT Id, Name FROM ApexClass WHERE Name = '$Name' LIMIT 1"
-    $result = Invoke-Salesforce -Command "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
+    $command = "sf data query --query `"$query`" --use-tooling-api --target-org $TargetOrg --json"
+    $result = Invoke-Salesforce -Command $command
     $parsed = $result | ConvertFrom-Json
     if ($parsed.status -ne 0) {
         throw ($parsed.message)

--- a/psfdx-packages/psfdx-packages.psm1
+++ b/psfdx-packages/psfdx-packages.psm1
@@ -9,12 +9,10 @@ function Get-SalesforcePackages {
         [Parameter(Mandatory = $true)][string] $DevHubUsername,
         [Parameter(Mandatory = $false)][switch] $IncludeExtendedPackageDetails
     )
-    $arguments = "package list --target-dev-hub $DevHubUsername"
-    if ($IncludeExtendedPackageDetails) {
-        $arguments += " --verbose"
-    }
-    $arguments += " --json"
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf package list --target-dev-hub $DevHubUsername"
+    if ($IncludeExtendedPackageDetails) { $command += " --verbose" }
+    $command += " --json"
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -40,21 +38,15 @@ function New-SalesforcePackage {
         [Parameter(Mandatory = $false)][string] $Description,
         [Parameter(Mandatory = $false)][switch] $NoNamespace
     )
-    if (! $Description) {
-        $Description = $Name
-    }
-    $arguments = "package create --name $Name --description $Description"
-    $arguments += " --path $Path"
-    $arguments += " --package-type $PackageType"
-    if ($IsOrgDependent) {
-        $arguments += " --org-dependent"
-    }
-    if ($NoNamespace) {
-        $arguments += " --no-namespace"
-    }
-    $arguments += " --target-dev-hub $DevHubUsername"
-    $arguments += " --json"
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    if (! $Description) { $Description = $Name }
+    $command = "sf package create --name $Name --description $Description"
+    $command += " --path $Path"
+    $command += " --package-type $PackageType"
+    if ($IsOrgDependent) { $command += " --org-dependent" }
+    if ($NoNamespace) { $command += " --no-namespace" }
+    $command += " --target-dev-hub $DevHubUsername"
+    $command += " --json"
+    $result = Invoke-Salesforce -Command $command
     $resultSfdx = Show-SalesforceResult -Result $result
     return $resultSfdx.Id
 }
@@ -66,12 +58,10 @@ function Remove-SalesforcePackage {
         [Parameter(Mandatory = $true)][string] $DevHubUsername,
         [Parameter(Mandatory = $false)][switch] $NoPrompt
     )
-    $arguments = "package delete --package $Name"
-    if ($NoPrompt) {
-        $arguments += " --no-prompt"
-    }
-    $arguments += " --target-dev-hub $DevHubUsername"
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    $command = "sf package delete --package $Name"
+    if ($NoPrompt) { $command += " --no-prompt" }
+    $command += " --target-dev-hub $DevHubUsername"
+    Invoke-Salesforce -Command $command
 }
 function New-SalesforcePackageVersion {
     [CmdletBinding()]
@@ -101,38 +91,25 @@ function New-SalesforcePackageVersion {
         $PackageId = $package.Id
     }
 
-    $arguments = "package version create --package $PackageId"
-    $arguments += " --target-dev-hub $DevHubUsername"
-    if ($Name) {
-        $arguments += " --version-name $Name"
-    }
-    if ($Description) {
-        $arguments += " --version-description $Description"
-    }
-    if ($Tag) {
-        $arguments += " --tag $Tag"
-    }
-    if ($CodeCoverage) {
-        $arguments += " --code-coverage"
-    }
-    $arguments += " --definition-file $ScratchOrgDefinitionFile"
+    $command = "sf package version create --package $PackageId"
+    $command += " --target-dev-hub $DevHubUsername"
+    if ($Name) { $command += " --version-name $Name" }
+    if ($Description) { $command += " --version-description $Description" }
+    if ($Tag) { $command += " --tag $Tag" }
+    if ($CodeCoverage) { $command += " --code-coverage" }
+    $command += " --definition-file $ScratchOrgDefinitionFile"
 
     if (($InstallationKeyBypass) -or (! $InstallationKey)) {
-        $arguments += " --installation-key-bypass"
-    }
-    else {
-        $arguments += " --installation-key $InstallationKey"
-    }
-
-    if ($SkipValidation) {
-        $arguments += " --skip-validation"
-    }
-    if ($WaitMinutes) {
-        $arguments += " --wait $WaitMinutes"
+        $command += " --installation-key-bypass"
+    } else {
+        $command += " --installation-key $InstallationKey"
     }
 
-    $arguments += " --json"
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    if ($SkipValidation) { $command += " --skip-validation" }
+    if ($WaitMinutes) { $command += " --wait $WaitMinutes" }
+
+    $command += " --json"
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -152,23 +129,15 @@ function Get-SalesforcePackageVersions {
         $PackageId = $package.Id
     }
 
-    $arguments = "package version list"
-    $arguments += " --target-dev-hub $DevHubUsername"
-    if ($PackageId) {
-        $arguments += " --packages $PackageId"
-    }
-    if ($Released) {
-        $arguments += " --released"
-    }
-    if ($Concise) {
-        $arguments += " --concise"
-    }
-    if ($ExtendedDetails) {
-        $arguments += " --verbose"
-    }
-    $arguments += " --json"
+    $command = "sf package version list"
+    $command += " --target-dev-hub $DevHubUsername"
+    if ($PackageId) { $command += " --packages $PackageId" }
+    if ($Released) { $command += " --released" }
+    if ($Concise) { $command += " --concise" }
+    if ($ExtendedDetails) { $command += " --verbose" }
+    $command += " --json"
 
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -180,15 +149,13 @@ function Promote-SalesforcePackageVersion {
         [Parameter(Mandatory = $false)][switch] $NoPrompt
     )
 
-    $arguments = "package version promote"
-    $arguments += " --package $PackageVersionId"
-    $arguments += " --target-dev-hub $DevHubUsername"
-    if ($NoPrompt) {
-        $arguments += " --no-prompt"
-    }
-    $arguments += " --json"
+    $command = "sf package version promote"
+    $command += " --package $PackageVersionId"
+    $command += " --target-dev-hub $DevHubUsername"
+    if ($NoPrompt) { $command += " --no-prompt" }
+    $command += " --json"
 
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -200,15 +167,13 @@ function Remove-SalesforcePackageVersion {
         [Parameter(Mandatory = $false)][switch] $NoPrompt
     )
 
-    $arguments = "package version delete"
-    $arguments += " --package $PackageVersionId"
-    $arguments += " --target-dev-hub $DevHubUsername"
-    if ($NoPrompt) {
-        $arguments += " --no-prompt"
-    }
-    $arguments += " --json"
+    $command = "sf package version delete"
+    $command += " --package $PackageVersionId"
+    $command += " --target-dev-hub $DevHubUsername"
+    if ($NoPrompt) { $command += " --no-prompt" }
+    $command += " --json"
 
-    $result = Invoke-Salesforce -Command ("sf " + $arguments)
+    $result = Invoke-Salesforce -Command $command
     return Show-SalesforceResult -Result $result
 }
 
@@ -221,15 +186,13 @@ function Install-SalesforcePackageVersion {
         [Parameter(Mandatory = $false)][int] $WaitMinutes = 10
     )
 
-    $arguments = "package install"
-    $arguments += " --package $PackageVersionId"
-    if ($TargetOrg) { $arguments += " --target-org $TargetOrg" }
-    if ($NoPrompt) {
-        $arguments += " --no-prompt"
-    }
+    $command = "sf package install"
+    $command += " --package $PackageVersionId"
+    if ($TargetOrg) { $command += " --target-org $TargetOrg" }
+    if ($NoPrompt) { $command += " --no-prompt" }
     if ($WaitMinutes) {
-        $arguments += " --wait $WaitMinutes"
-        $arguments += " --publish-wait $WaitMinutes"
+        $command += " --wait $WaitMinutes"
+        $command += " --publish-wait $WaitMinutes"
     }
-    Invoke-Salesforce -Command ("sf " + $arguments)
+    Invoke-Salesforce -Command $command
 }


### PR DESCRIPTION
This PR refactors modules to construct a single PowerShell `$command string for all Salesforce CLI calls, replacing inline ("sf " + `$arguments) concatenations.

- Standardizes Invoke-Salesforce usage across psfdx, psfdx-metadata, and psfdx-packages
- No behavior changes; improves readability and maintainability

If you prefer a different branch name or message tweaks, I can adjust.